### PR TITLE
Added udMatrixEqualApprox to compare udMatrix4x4.

### DIFF
--- a/Include/udMath.h
+++ b/Include/udMath.h
@@ -234,6 +234,7 @@ template <typename T> udQuaternion<T> udConjugate(const udQuaternion<T> &q);
 template <typename T> udQuaternion<T> udSlerp(const udQuaternion<T> &q1, const udQuaternion<T> &q2, double t);
 
 template <typename V> bool udEqualApprox(const V &a, const V &b, typename V::ElementType epsilon = UD_EPSILON);
+template <typename T> bool udMatrixEqualApprox(const udMatrix4x4<T> &a, const udMatrix4x4<T> &b, T epsilon = (T)(UD_EPSILON));
 
 template <typename T> udVector3<T> udDirectionFromYPR(const udVector3<T> &ypr);
 template <typename T> udVector3<T> udDirectionToYPR(const udVector3<T> &direction);

--- a/Include/udMath_Inl.h
+++ b/Include/udMath_Inl.h
@@ -223,6 +223,16 @@ inline bool udEqualApprox(const V &a, const V &b, typename V::ElementType epsilo
 }
 
 template <typename T>
+inline bool udMatrixEqualApprox(const udMatrix4x4<T> &a, const udMatrix4x4<T> &b, T epsilon)
+{
+  for (int i = 0; i < udMatrix4x4<T>::ElementCount; ++i)
+    if (udAbs(a.a[i] - b.a[i]) > epsilon)
+      return false;
+
+  return true;
+}
+
+template <typename T>
 inline T udNormaliseRotation(T rad, T absRange)
 {
   absRange = udAbs(absRange);

--- a/udTest/src/udMathTests.cpp
+++ b/udTest/src/udMathTests.cpp
@@ -102,7 +102,7 @@ bool udQuaternion_SlerpAxisAngleUnitTest(udQuaternion<T> q0, udQuaternion<T> q1,
   if (udAbs(2.0 * halfTheta - T(UD_PI)) < thetaEpsilon)
     return true;
 
-  // If the rotation is greater than PI (180°) neqate q1 to take the shortest path along the arc
+  // If the rotation is greater than PI (180Â°) neqate q1 to take the shortest path along the arc
   udQuaternion<T> q1c = cosHalfTheta < T(0) ? -q1 : q1;
   udQuaternion<T> qr = udMul(udConjugate(q0), q1c);
 
@@ -245,6 +245,35 @@ bool EqualApproxUnitTest()
 }
 
 template <typename T>
+bool MatrixEqualApproxUnitTest()
+{
+  const T epsilon = T(0.01);
+  udMatrix4x4<T> a;
+  udMatrix4x4<T> b;
+  udMatrix4x4<T> c;
+
+  const int count = udMatrix4x4<T>::ElementCount;
+
+  for (int i = 0; i < count; ++i)
+  {
+    a.a[i] = T(0);
+    b.a[i] = T(0.001);
+    c.a[i] = T(0.02);
+  }
+
+  if (!udMatrixEqualApprox(a, a, epsilon))
+    return false;
+
+  if (!udMatrixEqualApprox(a, b, epsilon))
+    return false;
+
+  if (udMatrixEqualApprox(a, c, epsilon))
+    return false;
+
+  return true;
+}
+
+template <typename T>
 bool IsUnitLengthUnitTest()
 {
   typedef typename T::ElementType ET;
@@ -286,7 +315,7 @@ void udQuaternion_SlerpAssertUnitLengthQ1()
   udSlerp(qi, q0, T(0.5)); // This should assert
 }
 
-// FAIL Test assert for slerping quaternions separated by an angle of PI (180°)
+// FAIL Test assert for slerping quaternions separated by an angle of PI (180Â°)
 template <typename T>
 void udQuaternion_SlerpAssertPITheta()
 {
@@ -368,6 +397,9 @@ TEST(MathTests, UnitLengthCanaries)
   EXPECT_TRUE(EqualApproxUnitTest<udVector4<double> >());
   EXPECT_TRUE(EqualApproxUnitTest<udQuaternion<float> >());
   EXPECT_TRUE(EqualApproxUnitTest<udQuaternion<double> >());
+
+  EXPECT_TRUE(MatrixEqualApproxUnitTest<float>());
+  EXPECT_TRUE(MatrixEqualApproxUnitTest<double>());
 
   EXPECT_TRUE(IsUnitLengthUnitTest<udVector2<float> >());
   EXPECT_TRUE(IsUnitLengthUnitTest<udVector2<double> >());


### PR DESCRIPTION
Related to AB#1166. 

Added udMatrixEqualApprox for udMatrix4x4<float> and udMatrix4x4<double>.