### PR TITLE
Rewrote udCreateDir to work on network drives

### DIFF
--- a/Include/udPlatformUtil.h
+++ b/Include/udPlatformUtil.h
@@ -326,11 +326,11 @@ udResult udReadDir(udFindDir *pFindDir);
 // Free resources associated with the directory
 udResult udCloseDir(udFindDir **ppFindDir);
 
-// Create a folder
-udResult udCreateDir(const char *pFolder, int *pNewFolders = nullptr);
+// Create a directory, potentially creating other directories in the path leading to it
+udResult udCreateDir(const char *pDirPath, int *pDirsCreatedCount = nullptr);
 
-// Removes a folder
-udResult udRemoveDir(const char *pFolder);
+// Removes a folder and a number of sub-folders (pass count returned by udCreateDir to undo; passing zero will not remove the folder)
+udResult udRemoveDir(const char *pDirPath, int removeCount = 1);
 
 // *********************************************************************
 // Geospatial helper functions

--- a/Source/udFileHandler_FILE.cpp
+++ b/Source/udFileHandler_FILE.cpp
@@ -114,7 +114,7 @@ udResult udFileHandler_FILEOpen(udFile **ppFile, const char *pFilename, udFileOp
   {
     udFilename temp(pFile->pFilenameCopy);
     temp.SetFilenameWithExt("");
-    UD_ERROR_CHECK(udCreateDir(temp.GetPath()));
+    udCreateDir(temp.GetPath()); // Don't error check, it will fail on file create if there are problems
   }
 
   result = udFileExists(pFile->pFilenameCopy, &pFile->fileLength);

--- a/udTest/src/udFileTests.cpp
+++ b/udTest/src/udFileTests.cpp
@@ -388,8 +388,7 @@ TEST(udFileTests, RecursiveCreateDirectoryTests)
   EXPECT_EQ(1, newFolders);
   EXPECT_EQ(udR_Success, udCreateDir("./dir/two/more", &newFolders));
   EXPECT_EQ(2, newFolders);
-  EXPECT_EQ(udR_Success, udRemoveDir("./dir/two/more"));
-  EXPECT_EQ(udR_Success, udRemoveDir("./dir/two"));
+  EXPECT_EQ(udR_Success, udRemoveDir("./dir/two/more", 2));
   EXPECT_EQ(udR_Success, udRemoveDir("./dir"));
 
   // Empty directory should always succeed


### PR DESCRIPTION
udCreateDir is now much more efficient, it was making many unnecessary calls and allocations in the simple case of creating a single directory.

udRemoveDir is now able to undo udCreateDir's work accurately also