### PR TITLE
Removed the millisecond versions of GetEpoch

### DIFF
--- a/Include/udPlatformUtil.h
+++ b/Include/udPlatformUtil.h
@@ -97,8 +97,6 @@ int udDaysUntilExpired(int maxDays, const char **ppExpireDateStr); // Return the
 
 int64_t udGetEpochSecsUTCd();
 double udGetEpochSecsUTCf();
-int64_t udGetEpochMilliSecsUTCd();
-double udGetEpochMilliSecsUTCf();
 
 #if UDPLATFORM_WINDOWS
 // *********************************************************************

--- a/Source/udPlatformUtil.cpp
+++ b/Source/udPlatformUtil.cpp
@@ -205,20 +205,6 @@ double udGetEpochSecsUTCf()
   return 1.0 * std::chrono::system_clock::now().time_since_epoch().count() / std::chrono::system_clock::period::den;
 }
 
-// ****************************************************************************
-// Author: Paul Fox, July 2019
-int64_t udGetEpochMilliSecsUTCd()
-{
-  return 1000 * std::chrono::system_clock::now().time_since_epoch().count() / std::chrono::system_clock::period::den;
-}
-
-// ****************************************************************************
-// Author: Paul Fox, July 2019
-double udGetEpochMilliSecsUTCf()
-{
-  return 1000.0 * std::chrono::system_clock::now().time_since_epoch().count() / std::chrono::system_clock::period::den;
-}
-
 #if UDPLATFORM_WINDOWS
 // *********************************************************************
 // Author: Dave Pevreal, June 2015


### PR DESCRIPTION
Fixes [AB#2678](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2678)