### PR TITLE
Fixed issue move constructor and move assignment operator causing crashes

### DIFF
--- a/Source/udPlatformUtil.cpp
+++ b/Source/udPlatformUtil.cpp
@@ -454,7 +454,11 @@ udFilename &udFilename::operator=(const udFilename &o)
 // Author: Samuel Surtees, July 2021
 udFilename::udFilename(udFilename &&o) noexcept
 {
-  this->pPath = o.pPath;
+  if (o.pPath == o.path)
+    this->pPath = this->path;
+  else
+    this->pPath = o.pPath;
+
   o.pPath = nullptr;
   memmove(this->path, o.path, udLengthOf(this->path));
   this->filenameIndex = o.filenameIndex;
@@ -465,7 +469,11 @@ udFilename::udFilename(udFilename &&o) noexcept
 // Author: Samuel Surtees, July 2021
 udFilename &udFilename::operator=(udFilename &&o) noexcept
 {
-  this->pPath = o.pPath;
+  if (o.pPath == o.path)
+    this->pPath = this->path;
+  else
+    this->pPath = o.pPath;
+
   o.pPath = nullptr;
   memmove(this->path, o.path, udLengthOf(this->path));
   this->filenameIndex = o.filenameIndex;

--- a/udTest/src/udFilenameTests.cpp
+++ b/udTest/src/udFilenameTests.cpp
@@ -141,6 +141,53 @@ TEST(udFilenameTests, Validate)
     EXPECT_STREQ(".ext", fn.GetExt());
   }
 
+  // Test copy assignment operator
+  {
+    udFilename fn = filenameWithFolderAndExt;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn.GetPath());
+    udFilename fn2;
+    fn2 = fn;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn2.GetPath());
+
+    // Confirm values are copied correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+    EXPECT_STRNE(fn.GetPath(), fn2.GetPath());
+  }
+
+  // Test copy constructor
+  {
+    udFilename fn = filenameWithFolderAndExt;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn.GetPath());
+    udFilename fn2 = fn;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn2.GetPath());
+
+    // Confirm values are copied correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+    EXPECT_STRNE(fn.GetPath(), fn2.GetPath());
+  }
+
+  // Test move assignment operator
+  {
+    udFilename fn = filenameWithFolderAndExt;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn.GetPath());
+    udFilename fn2;
+    fn2 = std::move(fn);
+    EXPECT_STREQ(filenameWithFolderAndExt, fn2.GetPath());
+
+    // Confirm values are moved correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+  }
+
+  // Test move constructor
+  {
+    udFilename fn = filenameWithFolderAndExt;
+    EXPECT_STREQ(filenameWithFolderAndExt, fn.GetPath());
+    udFilename fn2 = std::move(fn);
+    EXPECT_STREQ(filenameWithFolderAndExt, fn2.GetPath());
+
+    // Confirm values are moved correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -178,5 +225,49 @@ TEST(udFilenameTests, LongFilenameValidate)
     EXPECT_STREQ(filenameSuperLongFilename, pFilename);
     EXPECT_EQ(requiredSize, udStrlen(pFilename) + 1);
     udFree(pFilename);
+  }
+
+  // Test copy assignment operator
+  {
+    udFilename fn2;
+    fn2 = fn;
+    EXPECT_STREQ(filenameSuperLong, fn2.GetPath());
+
+    // Confirm values are copied correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+    EXPECT_STRNE(fn.GetPath(), fn2.GetPath());
+  }
+
+  // Test copy constructor
+  {
+    udFilename fn2 = fn;
+    EXPECT_STREQ(filenameSuperLong, fn2.GetPath());
+
+    // Confirm values are copied correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+    EXPECT_STRNE(fn.GetPath(), fn2.GetPath());
+  }
+
+  // Test move assignment operator
+  {
+    udFilename fn1 = filenameSuperLong;
+    EXPECT_STREQ(filenameSuperLong, fn1.GetPath());
+    udFilename fn2;
+    fn2 = std::move(fn1);
+    EXPECT_STREQ(filenameSuperLong, fn2.GetPath());
+
+    // Confirm values are moved correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
+  }
+
+  // Test move constructor
+  {
+    udFilename fn1 = filenameSuperLong;
+    EXPECT_STREQ(filenameSuperLong, fn1.GetPath());
+    udFilename fn2 = std::move(fn1);
+    EXPECT_STREQ(filenameSuperLong, fn2.GetPath());
+
+    // Confirm values are moved correctly, should crash if `pPath` isn't set properly
+    EXPECT_TRUE(fn2.SetExtension(".test"));
   }
 }


### PR DESCRIPTION
- Added tests for copy and move constructors and assignment operators