### PR TITLE
Added Windows ARM64 support to Mbed TLS

### DIFF
--- a/3rdParty/mbedtls/UpdateSteps.txt
+++ b/3rdParty/mbedtls/UpdateSteps.txt
@@ -2,3 +2,5 @@
 2. Copy from the release package
 3. Restore threading_alt.h
 4. Enable MBEDTLS_THREADING_ALT and MBEDTLS_THREADING_C in config.h
+5. Enable MBEDTLS_HAVE_INT64 in bignum.h for Windows ARM64 builds using _M_ARM64 macro
+6. Disable optimisations for mbedtls_mpi_safe_cond_assign in Windows ARM64 builds using _MSC_VER and _M_ARM64 macro

--- a/3rdParty/mbedtls/include/mbedtls/bignum.h
+++ b/3rdParty/mbedtls/include/mbedtls/bignum.h
@@ -115,7 +115,7 @@
  * disabled by defining MBEDTLS_NO_UDBL_DIVISION.
  */
 #if !defined(MBEDTLS_HAVE_INT32)
-    #if defined(_MSC_VER) && defined(_M_AMD64)
+    #if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_ARM64))
         /* Always choose 64-bit when using MSC */
         #if !defined(MBEDTLS_HAVE_INT64)
             #define MBEDTLS_HAVE_INT64

--- a/3rdParty/mbedtls/library/bignum.c
+++ b/3rdParty/mbedtls/library/bignum.c
@@ -334,6 +334,9 @@ static void mpi_safe_cond_assign( size_t n,
  * about whether the assignment was made or not.
  * (Leaking information about the respective sizes of X and Y is ok however.)
  */
+#if defined(_MSC_VER) && defined(_M_ARM64)
+#pragma optimize("", off)
+#endif
 int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned char assign )
 {
     int ret = 0;
@@ -370,6 +373,9 @@ int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned
 cleanup:
     return( ret );
 }
+#if defined(_MSC_VER) && defined(_M_ARM64)
+#pragma optimize("", on)
+#endif
 
 /*
  * Conditionally swap X and Y, without leaking information


### PR DESCRIPTION
- Disabled optimisations on mbedtls_mpi_safe_cond_assign to avoid bad code generation