### PR TITLE
Fixed issue with udStrstr ignoring matches after partial matches

### DIFF
--- a/Source/udStringUtil.cpp
+++ b/Source/udStringUtil.cpp
@@ -369,6 +369,7 @@ const char *udStrstr_Internal(const char *pStr, size_t sLen, const char *pSubStr
     }
     else
     {
+      i -= subStringIndex;
       subStringIndex = 0;
     }
   }

--- a/udTest/src/udStrTests.cpp
+++ b/udTest/src/udStrTests.cpp
@@ -130,6 +130,13 @@ TEST(udStrTests, udStrstr)
   EXPECT_EQ(&input[24], udStrstr(input, UDARRAYSIZE(input), "special"));
   EXPECT_STREQ(input, udStrstri(input, udLengthOf(input), "th"));
   EXPECT_STREQ(input, udStrstri(input, udLengthOf(input), "TH"));
+
+  // Special cases
+  const char specialInput[] = "]]]]>";
+  // Partial match overlapping with actual match
+  EXPECT_STREQ(&specialInput[1], udStrstr(specialInput, udLengthOf(specialInput), "]]]>"));
+  // Partial match immediately before actual match
+  EXPECT_STREQ(&specialInput[2], udStrstr(specialInput, udLengthOf(specialInput), "]]>"));
 }
 
 TEST(udStrTests, udStrAto)


### PR DESCRIPTION
Fixes [AB#5248](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/5248)