### PR TITLE
New geometry tools and tests

### DIFF
--- a/Include/udGeometryTools.h
+++ b/Include/udGeometryTools.h
@@ -1,0 +1,387 @@
+#ifndef UDGEOMETRYTOOLS_H
+#define UDGEOMETRYTOOLS_H
+
+#include "udMath.h"
+
+/*
+//------------------------------------------------------------------------
+   THE GOAL
+//------------------------------------------------------------------------
+
+ The purpose of this library is to collect all common and reusable geometry code in a single place
+ for convenience and testing. 
+
+ udGeometry values: Correctness, speed and robustness.
+
+//------------------------------------------------------------------------
+   GEOMETRY TYPES
+//------------------------------------------------------------------------
+
+ * Examples include lines, circles, spheres, planes and boxes.
+ * A geometry type will have public access to data members, to follow the convention of other udMath types.
+ * To construct a geomtery type, the Set() functions should be used to ensure legitimate construction, and avoid degeneracy.
+   A dengenerate class can be thought of as a class of objects that are qualitativily different (and simpler than) the rest of the class.
+   For example a point is a degenerate circle with radius 0, a line is degenerate triangle with all colinier points.
+ * Any method taking a geometry type can assume it is legitimate
+
+//------------------------------------------------------------------------
+   GEOMETRY QUERIES
+//------------------------------------------------------------------------
+
+ * There will be three types of geometry queries:
+      Closest Points        (udGeometry_CP*): Closest points between two geometries.
+      Test for Intersection (udGeometry_TI*): Determine if two geometries are intersecting. No other output may be given other than a
+                                              boolean. TI queries are usually faster to perform than FI as we can stop once we
+                                              determine intersection state.
+      Find Intersection     (udGeometry_FI*): Find the intersection space between two geometries. Can be more intensive then TI querieas as we not
+                                              only want to determine if the two geometries are intersecting, but we need to construct the geometry
+                                              that defines the intersection space. For example, a line vs triangle FI query in 3D might return nothing,
+                                              a point or a segment (line is on the plane of the triangle).
+ * A query with a degenerate type will have undefined behaviour
+*/
+
+//------------------------------------------------------------------------
+// Constants and Types
+//------------------------------------------------------------------------
+
+// If UD_USE_EXACT_MATH is defined, values are compared for exactness,
+// otherwise a tolerance is used
+
+// These should be separate form udResult as they are not really error codes, but more describe the interaction between objects
+enum udGeometryCode
+{
+  udGC_Success,
+  udGC_Overlapping,
+  udGC_Parallel,
+  udGC_Coincident,
+  udGC_Intersecting,
+  udGC_NotIntersecting,
+  udGC_CompletelyInside,
+  udGC_CompletelyOutside,
+  udGC_OnBoundary,
+};
+
+// Many geometry queries can use the same algotirhm for both 2D and 3D, so we abstract away the dimension...
+#define udVector_t typename udSpace<T, R>::vector_t
+
+template<typename T, int R> struct udSpace;
+template<typename T> struct udSpace<T, 2> { typedef udVector2<T> vector_t; };
+template<typename T> struct udSpace<T, 3> { typedef udVector3<T> vector_t; };
+
+//--------------------------------------------------------------------------------
+// Geometry Types
+//--------------------------------------------------------------------------------
+
+template<typename T>
+class udPlane
+{
+public:
+
+  udResult Set(const udVector3<T> &p0, const udVector3<T> &p1, const udVector3<T> &p2);
+  udResult Set(const udVector3<T> &point, const udVector3<T> &_normal);
+
+  udVector3<T> normal;
+  T offset;
+};
+
+template<typename T, int R>
+class udAABB
+{
+public:
+
+  udResult Set(const udVector_t &minPt, const udVector_t &maxPt);
+  void Merge(udAABB const &other);
+  udVector_t GetCentre() const {return (minPoint + maxPoint) * T(0.5);}
+
+  udVector_t minPoint;
+  udVector_t maxPoint;
+};
+
+template<typename T, int R>
+class udLine
+{
+public:
+
+  udResult SetFromEndPoints(const udVector_t &p0, const udVector_t &p1);
+  udResult SetFromDirection(const udVector_t &p0, const udVector_t &dir);
+
+  udVector_t origin;
+  udVector_t direction;
+};
+
+template<typename T, int R>
+class udRay
+{
+public:
+
+  udResult SetFromEndPoints(const udVector_t &p0, const udVector_t &p1);
+  udResult SetFromDirection(const udVector_t &p0, const udVector_t &dir);
+
+  udVector_t origin;
+  udVector_t direction;
+};
+
+template<typename T, int R>
+class udSegment
+{
+public:
+
+  udResult Set(const udVector_t &_p0, const udVector_t &_p1);
+  udResult GetCenteredForm(udVector_t *pCentre, udVector_t *pDirection, udVector_t *pExtent) const;
+  udVector_t Direction() const { return p1 - p0; }
+  T Length() const { return udMag(p1 - p0); }
+  T LengthSq() const { return udMagSq(p1 - p0); }
+
+  udVector_t p0;
+  udVector_t p1;
+};
+
+template<typename T, int R>
+class udHyperSphere
+{
+public:
+
+  udResult Set(const udVector_t & _centre, T _radius);
+
+  udVector_t centre;
+  T radius;
+};
+
+template<typename T, int R>
+class udTriangle
+{
+public:
+
+  udResult Set(const udVector_t & _p0, const udVector_t & _p1, const udVector_t & _p2);
+
+  T GetArea() const;
+  udVector3<T> GetSideLengths() const;
+  udResult GetSide(uint32_t i, udSegment<T, R> *pSeg) const;
+
+  union
+  {
+    struct
+    {
+      udVector_t p0;
+      udVector_t p1;
+      udVector_t p2;
+    } pt;
+    udVector_t ary[3];
+  };
+};
+
+template <typename T> using udAABB2 = udAABB<T, 2>;
+template <typename T> using udAABB3 = udAABB<T, 3>;
+template <typename T> using udLine2 = udLine<T, 2>;
+template <typename T> using udLine3 = udLine<T, 3>;
+template <typename T> using udRay2 = udRay<T, 2>;
+template <typename T> using udRay3 = udRay<T, 3>;
+template <typename T> using udSegment2 = udSegment<T, 2>;
+template <typename T> using udSegment3 = udSegment<T, 3>;
+template <typename T> using udTriangle2 = udTriangle<T, 2>;
+template <typename T> using udTriangle3 = udTriangle<T, 3>;
+template <typename T> using udCircle2 = udHyperSphere<T, 2>;
+template <typename T> using udDisk2 = udHyperSphere<T, 2>; // The region bounded by a circle
+template <typename T> using udSphere = udHyperSphere<T, 3>;
+template <typename T> using udBall = udHyperSphere<T, 3>;  // The region bounded by a sphere
+
+//********************************************************************************
+// Utility
+//********************************************************************************
+
+template<uint32_t P> constexpr float udQuickPowf(float x) {return x * udQuickPowf<P - 1>(x);}
+template<> constexpr float udQuickPowf<0>(float x) {udUnused(x); return 1.f;}
+
+template<uint32_t P> constexpr double udQuickPowd(double x) {return x * udQuickPowd<P - 1>(x);}
+template<> constexpr double udQuickPowd<0>(double x) {udUnused(x); return 1.0;}
+
+template<typename T> bool udAreEqual(T a, T b);
+template<typename T, int R> bool udAreEqual(const udVector_t &v0, const udVector_t &v1);
+
+// If UD_USE_EXACT_MATH is not defined, this function tests if value is within an epsilon of zero, as defined in udGetEpsilon().
+// Otherwise it will test if value == T(0)
+template<typename T> bool udIsZero(T value);
+
+// Utility function to sort two values
+template<typename T> void udGeometry_SortLowToHigh(T &a, T &b);
+
+// Utility function to sort vector elements
+template<typename T> udVector3<T> udGeometry_SortLowToHigh(const udVector3<T> &a);
+
+// Utility function to sum vector elements
+template<typename T, int R> T udGeometry_Sum(const udVector_t &v);
+
+// The scalar triple product is defined as ((v x u) . w), which is equivilent to the signed
+// volume of the parallelepiped formed by the three vectors u, v and w.
+template<typename T> T udGeometry_ScalarTripleProduct(const udVector3<T> &u, const udVector3<T> &v, const udVector3<T> &w);
+
+// Compute the barycentric coordinates of a point wrt a triangle.
+template<typename T, int R> udResult udGeometry_Barycentric(const udTriangle<T, R> &tri, const udVector_t &p, udVector3<T> *pUVW);
+
+template<typename T> udResult SetRotationAround(const udRay3<T> & ray, const udVector3<T> & center, const udVector3<T> & axis, const T & angle, udRay3<T> *pOut);
+
+//********************************************************************************
+// Distance Queries
+//********************************************************************************
+
+// Compute the signed distance between a plane and point
+template<typename T> T udGeometry_SignedDistance(const udPlane<T> &plane, const udVector3<T> &point);
+
+//********************************************************************************
+// Intersection Test Queries
+//********************************************************************************
+
+//-----------------------------------------
+// udGeometry_TIPointAABB()
+// Geometry codes: udGC_Intersecting, udGC_NotIntersecting
+template<typename T, int R> udResult udGeometry_TIPointAABB(const udVector_t &point, const udAABB<T, R> &box, udGeometryCode *pCode);
+
+//-----------------------------------------
+// udGeometry_TIAABBAABB()
+// Geometry codes: udGC_Intersecting, udGC_NotIntersecting
+template<typename T, int R> udResult udGeometry_TIAABBAABB(const udAABB<T, R> &box0, const udAABB<T, R> &box1, udGeometryCode *pCode);
+
+//-----------------------------------------
+// udGeometry_TI2PointPolygon()
+// Geometry codes: udGC_CompletelyInside, udGC_CompletelyOutside, udGC_OnBoundary
+template<typename T> udResult udGeometry_TI2PointPolygon(const udVector2<T> &point, const udVector2<T> *pPoints, size_t pointCount, udGeometryCode *pCode);
+
+//********************************************************************************
+// Closest Points Queries
+//********************************************************************************
+
+//-----------------------------------------
+// udGeometry_CP3PointPlane()
+template<typename T> udResult udGeometry_CP3PointPlane(const udVector3<T> &point, const udPlane<T> &plane,  udVector3<T> *pOut);
+
+//-----------------------------------------
+// udGeometry_CPPointLine()
+template<typename T, int R>
+struct udCPPointLineResult
+{
+  udVector_t point;
+  T u; // Distance along the line to closest point
+};
+template<typename T, int R> udResult udGeometry_CPPointLine(const udVector_t &point, const udLine<T, R> &line, udCPPointLineResult<T, R> *pData);
+
+//-----------------------------------------
+// udGeometry_CPPointSegment()
+template<typename T, int R>
+struct udCPPointSegmentResult
+{
+  udVector_t point;
+  T u; // Distance along the line to closest point
+};
+template<typename T, int R> udResult udGeometry_CPPointSegment(const udVector_t &point, const udSegment<T, R> &seg, udCPPointSegmentResult<T, R> *pData);
+
+//-----------------------------------------
+// udGeometry_CPSegmentSegment()
+// Geometry codes: udGC_Success
+//                 udGC_Overlapping if the segments are overlapping in a way that produces an infinite number of closest points. In this case, a point is chosen along this region to be the closest points set.
+template<typename T, int R>
+struct udCPSegmentSegmentResult
+{
+  udGeometryCode code;
+  udVector_t cp_a;
+  udVector_t cp_b;
+  T u_a;
+  T u_b;
+};
+template<typename T, int R> udResult udGeometry_CPSegmentSegment(const udSegment<T, R> & seg_a, const udSegment<T, R> & seg_b, udCPSegmentSegmentResult<T, R> * pResult);
+
+//-----------------------------------------
+// udGeometry_CPLineLine()
+// Geometry codes: udGC_Success
+//                 udGC_Parallel if the segments are overlapping in a way that produces an infinite number of closest points. In this case, a point is chosen along this region to be the closest points set.
+template<typename T, int R>
+struct udCPLineLineResult
+{
+  udGeometryCode code;
+  udVector_t cp_a;
+  udVector_t cp_b;
+  T u_a;
+  T u_b;
+};
+template<typename T, int R> udResult udGeometry_CPLineLine(const udLine<T, R> & line_a, const udLine<T, R> & line_b, udCPLineLineResult<T, R> *pResult);
+
+//-----------------------------------------
+// udGeometry_CPLineSegment()
+// Geometry codes: udGC_Success
+//                 udGC_Parallel if the segments are overlapping in a way that produces an infinite number of closest points. In this case, a point is chosen along this region to be the closest points set.
+template<typename T, int R>
+struct udCPLineSegmentResult
+{
+  udGeometryCode code;
+  udVector_t cp_l;
+  udVector_t cp_s;
+  T u_l;
+  T u_s;
+};
+template<typename T, int R> udResult udGeometry_CPLineSegment(const udLine<T, R> &line, const udSegment<T, R> &seg, udCPLineSegmentResult<T, R> *pResult);
+
+//-----------------------------------------
+// udGeometry_CPPointTriangle()
+template<typename T, int R> udResult udGeometry_CPPointTriangle(const udVector_t &point, const udTriangle<T, R> &tri, udVector_t *pOut);
+
+//********************************************************************************
+// Find Intersection Queries
+//********************************************************************************
+
+//-----------------------------------------
+// udGeometry_FI3SegmentPlane()
+// Geometry codes: udGC_Intersecting
+//                 udGC_NotIntersecting
+//                 udGC_Coincident
+template<typename T>
+struct udFI3SegmentPlaneResult
+{
+  udGeometryCode code;
+  udVector3<T> point;
+  T u;
+};
+template<typename T> udResult udGeometry_FI3SegmentPlane(const udSegment3<T> & seg, const udPlane<T> & plane, udFI3SegmentPlaneResult<T> * pData);
+
+//-----------------------------------------
+// udGeometry_FI3SegmentTriangle()
+// Geometry codes: udGC_Intersecting
+//                 udGC_NotIntersecting
+//                 udGC_Overlapping (produces segment)
+template<typename T>
+struct udFI3SegmentTriangleResult
+{
+  udGeometryCode code;
+  union
+  {
+    struct
+    {
+      udVector3<T> point;
+      T u;
+    } intersecting;
+
+    struct
+    {
+      udSegment3<T> segment;
+      T u_0;
+      T u_1;
+    } overlapping;
+  };
+};
+template<typename T> udResult udGeometry_FI3SegmentTriangle(const udSegment3<T> &seg, const udTriangle3<T> &tri, udFI3SegmentTriangleResult<T> *pResult);
+
+//-----------------------------------------
+// udGeometry_FI3RayPlane()
+// Geometry codes: udGC_Intersecting
+//                 udGC_NotIntersecting
+//                 udGC_Coincident
+template<typename T>
+struct udFI3RayPlaneResult
+{
+  udGeometryCode code;
+  udVector3<T> point;
+  T u;
+};
+template<typename T> udResult udGeometry_FI3RayPlane(const udRay3<T> & ray, const udPlane<T> & plane, udFI3RayPlaneResult<T> * pResult);
+
+#include "udGeometryTools_Inl.h"
+
+#endif

--- a/Include/udGeometryTools_Inl.h
+++ b/Include/udGeometryTools_Inl.h
@@ -1,0 +1,1124 @@
+
+#ifdef UD_USE_EXACT_MATH
+template<typename T> bool udIsZero(T value) { return value == T(0); }
+#else
+template<typename T> bool udIsZero(T value) { return udAbs(value) < udGetEpsilon<T>(); }
+#endif
+
+//------------------------------------------------------------------------------------
+// udPlane
+//------------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+udResult udPlane<T>::Set(const udVector3<T> &p0, const udVector3<T> &p1, const udVector3<T> &p2)
+{
+  udResult result;
+
+  //Get plane vector
+  udVector3<T> u = p1 - p0;
+  udVector3<T> v = p2 - p0;
+  udVector3<T> w = udCross3(u, v);
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(w);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  normal = w / udSqrt(lensq);
+  offset = udDot(-p0, normal);
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+udResult udPlane<T>::Set(const udVector3<T> &point, const udVector3<T> &_normal)
+{
+  udResult result;
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(_normal);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  normal = _normal / udSqrt(lensq);
+  offset = -udDot(point, normal);
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// udAABB
+//------------------------------------------------------------------------------------
+
+template<typename T, int R>
+udResult udAABB<T, R>::Set(const udVector_t &minPt, const udVector_t &maxPt)
+{
+  udResult result;
+
+  UD_ERROR_IF(minPt.x > maxPt.x, udR_Failure);
+  UD_ERROR_IF(minPt.y > maxPt.y, udR_Failure);
+  UD_ERROR_IF(minPt.z > maxPt.z, udR_Failure);
+
+  minPoint = minPt;
+  maxPoint = maxPt;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+template<typename T, int R>
+void udAABB<T, R>::Merge(udAABB<T, R> const &other)
+{
+  for (int i = 0; i < R; i++)
+  {
+    minPoint[i] = udMin(minPoint[i], other.minPoint[i]);
+    maxPoint[i] = udMax(maxPoint[i], other.maxPoint[i]);
+  }
+}
+
+//------------------------------------------------------------------------------------
+// udLine
+//------------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T, int R>
+udResult udLine<T, R>::SetFromEndPoints(const udVector_t &p0, const udVector_t &p1)
+{
+  udResult result;
+  udVector_t v = p1 - p0;
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(v);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  direction = v / udSqrt(lensq);
+  origin = p0;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T, int R>
+udResult udLine<T, R>::SetFromDirection(const udVector_t &p0, const udVector_t &dir)
+{
+  udResult result;
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(dir);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  direction = dir / udSqrt(lensq);
+  origin = p0;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// udRay
+//------------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, November 2021
+template<typename T, int R>
+udResult udRay<T, R>::SetFromEndPoints(const udVector_t &p0, const udVector_t &p1)
+{
+  udResult result;
+  udVector_t v = p1 - p0;
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(v);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  direction = v / udSqrt(lensq);
+  origin = p0;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, November 2021
+template<typename T, int R>
+udResult udRay<T, R>::SetFromDirection(const udVector_t &p0, const udVector_t &dir)
+{
+  udResult result;
+
+  //normalise for cheap distance checks
+  T lensq = udMagSq(dir);
+
+  UD_ERROR_IF(udIsZero(lensq), udR_Failure);
+
+  direction = dir / udSqrt(lensq);
+  origin = p0;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// udSegment
+//------------------------------------------------------------------------------------
+
+template<typename T, int R>
+udResult udSegment<T, R>::Set(const udVector_t &_p0, const udVector_t &_p1)
+{
+  udResult result;
+
+  UD_ERROR_IF((udAreEqual<T, R>(_p0, _p1)), udR_Failure);
+
+  p0 = _p0;
+  p1 = _p1;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+template<typename T, int R>
+udResult udSegment<T, R>::GetCenteredForm(udVector_t *pCentre, udVector_t *pDirection, udVector_t *pExtent) const
+{
+  udResult result;
+  T lenSq;
+
+  UD_ERROR_NULL(pCentre, udR_InvalidParameter);
+  UD_ERROR_NULL(pDirection, udR_InvalidParameter);
+  UD_ERROR_NULL(pExtent, udR_InvalidParameter);
+
+  *pCentre = T(0.5) * (p0 + p1);
+  *pDirection = p1 - p0;
+
+  lenSq = udMagSq(*pDirection);
+  UD_ERROR_IF(udIsZero(lenSq), udR_Failure);
+
+  *pExtent = T(0.5) * (*pDirection / udSqrt(lenSq));
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// udHyperSphere
+//------------------------------------------------------------------------------------
+
+template<typename T, int R>
+udResult udHyperSphere<T, R>::Set(const udVector_t & _centre, T _radius)
+{
+  udResult result;
+
+  UD_ERROR_IF(_radius < udGetEpsilon<T>(), udR_Failure);
+
+  centre = _centre;
+  radius = _radius;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// udTriangle
+//------------------------------------------------------------------------------------
+
+template<typename T, int R>
+udResult udTriangle<T, R>::Set(const udVector_t &_p0, const udVector_t &_p1, const udVector_t &_p2)
+{
+  udResult result;
+
+  udTriangle<T, R> temp;
+
+  temp.pt.p0 = _p0;
+  temp.pt.p1 = _p1;
+  temp.pt.p2 = _p2;
+
+  udVector3<T> sideLengths = udGeometry_SortLowToHigh(temp.GetSideLengths());
+
+  UD_ERROR_IF(udIsZero(sideLengths[2] - (sideLengths[0] + sideLengths[1])), udR_Failure);
+
+  pt.p0 = _p0;
+  pt.p1 = _p1;
+  pt.p2 = _p2;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T, int R>
+T udTriangle<T, R>::GetArea() const
+{
+  udVector3<T> sideLengths = GetSideLengths();
+  T p = (sideLengths[0] + sideLengths[1] + sideLengths[2]) / T(2);
+  T a = (p - sideLengths[0]);
+  T b = (p - sideLengths[1]);
+  T c = (p - sideLengths[2]);
+
+  // Floating point error, but should not occur if triangle created with Set()
+  UDASSERT(a > T(0), "Floating piont error");
+  UDASSERT(b > T(0), "Floating piont error");
+  UDASSERT(c > T(0), "Floating piont error");
+
+  return udSqrt(p * a * b * c);
+}
+
+// ****************************************************************************
+// Author: Frank Hart, November 2021
+template<typename T, int R>
+udVector3<T> udTriangle<T, R>::GetSideLengths() const
+{
+  return udVector3<T>::create(udMag(pt.p0 - pt.p1), udMag(pt.p0 - pt.p2), udMag(pt.p1 - pt.p2));
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T, int R>
+udResult udTriangle<T, R>::GetSide(uint32_t i, udSegment<T, R> * pSeg) const
+{
+  udResult result;
+
+  UD_ERROR_IF(i > 2 || pSeg == nullptr, udR_InvalidParameter);
+  UD_ERROR_CHECK(pSeg->Set(ary[i], ary[(i + 1) % 3]));
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//------------------------------------------------------------------------------------
+// Utility
+//------------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, July 2020
+template<typename T>
+bool udAreEqual(T a, T b)
+{
+  return udIsZero(a - b);
+}
+
+// ****************************************************************************
+// Author: Frank Hart, July 2020
+template<typename T, int R>
+bool udAreEqual(const udVector_t &v0, const udVector_t &v1)
+{
+  for (int i = 0; i < R; i++)
+  {
+    if (!udAreEqual(v0[i], v1[i]))
+      return false;
+  }
+  return true;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, July 2020
+template<typename T>
+T udGeometry_ScalarTripleProduct(const udVector3<T> &u, const udVector3<T> &v, const udVector3<T> &w)
+{
+  return udDot(udCross3(u, v), w);
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+void udGeometry_SortLowToHigh(T &a, T &b)
+{
+  if (b < a)
+  {
+    T temp = a;
+    a = b;
+    b = temp;
+  }
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+udVector3<T> udGeometry_SortLowToHigh(const udVector3<T> &a)
+{
+  udVector3<T> result = a;
+
+  udGeometry_SortLowToHigh(result[0], result[1]);
+  udGeometry_SortLowToHigh(result[0], result[2]);
+  udGeometry_SortLowToHigh(result[1], result[2]);
+
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T, int R>
+T udGeometry_Sum(const udVector_t &v)
+{
+  T total = v[0];
+  for (int i = 1; i < R; i++)
+    total += v[i];
+  return total;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, July 2020
+// Based on Real Time Collision Detection, Christer Ericson p184
+template<typename T, int R>
+udResult udGeometry_Barycentric(const udTriangle<T, R> &tri, const udVector_t &p, udVector3<T> *pUVW)
+{
+  udResult result;
+
+  udVector_t v0 = tri.pt.p1 - tri.pt.p0;
+  udVector_t v1 = tri.pt.p2 - tri.pt.p0;
+  udVector_t v2 = p - tri.pt.p0;
+
+  T d00 = udDot(v0, v0);
+  T d01 = udDot(v0, v1);
+  T d11 = udDot(v1, v1);
+  T d20 = udDot(v2, v0);
+  T d21 = udDot(v2, v1);
+
+  T denom = d00 * d11 - d01 * d01;
+
+  UD_ERROR_NULL(pUVW, udR_InvalidParameter);
+
+  // TODO we need a udR_DivideByZero
+  UD_ERROR_IF(udIsZero(denom), udR_Failure);
+
+  pUVW->y = (d11 * d20 - d01 * d21) / denom;
+  pUVW->z = (d00 * d21 - d01 * d20) / denom;
+  pUVW->x = T(1) - pUVW->y - pUVW->z;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+template <typename T>
+udResult SetRotationAround(const udRay3<T> & ray, const udVector3<T> & center, const udVector3<T> & axis, const T & angle, udRay3<T> * pOut)
+{
+  udResult result;
+  udVector3<T> origin = {};
+  udVector3<T> direction = {};
+  udQuaternion<T> rotation = {};
+
+  UD_ERROR_NULL(pOut, udR_InvalidParameter);
+
+  rotation = udQuaternion<T>::create(axis, angle);
+
+  direction = ray.origin - center; // find current direction relative to center
+  origin = center + rotation.apply(direction); // define new position
+  direction = udDirectionFromYPR((rotation * udQuaternion<T>::create(udDirectionToYPR(ray.direction))).eulerAngles()); // rotate object to keep looking at the center
+
+  UD_ERROR_CHECK(pOut->SetFromDirection(origin, direction));
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//--------------------------------------------------------------------------------
+// Distance Queries
+//--------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+T udGeometry_SignedDistance(const udPlane<T> &plane, const udVector3<T> &point)
+{
+  return udDot(point, plane.normal) + plane.offset;
+}
+
+//--------------------------------------------------------------------------------
+// Find Intersection Queries
+//--------------------------------------------------------------------------------
+
+template<typename T> udResult udGeometry_FI3SegmentPlane(const udSegment3<T> &seg, const udPlane<T> &plane, udFI3SegmentPlaneResult<T> *pData)
+{
+  udResult result;
+  T denom;
+
+  UD_ERROR_NULL(pData, udR_InvalidParameter);
+
+  denom = udDot(plane.normal, seg.Direction());
+
+  //check if line is parallel to plane
+  if (udIsZero(denom))
+  {
+    pData->u = T(0);
+
+    //check if line is on the plane
+    T dist = udAbs(udGeometry_SignedDistance(plane, seg.p0));
+
+    if (udIsZero(dist))
+      pData->code = udGC_Coincident;
+    else
+      pData->code = udGC_NotIntersecting;
+  }
+  else
+  {
+    pData->u = (-(udDot(seg.p0, plane.normal) + plane.offset) / denom);
+    if (pData->u < T(0))
+    {
+      pData->u = T(0);
+      pData->code = udGC_NotIntersecting;
+    }
+    else if (pData->u > T(1))
+    {
+      pData->u = T(1);
+      pData->code = udGC_NotIntersecting;
+    }
+    else
+    {
+      pData->code = udGC_Intersecting;
+    }
+  }
+
+  pData->point = seg.p0 + pData->u * seg.Direction();
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//--------------------------------------------------------------------------------
+// Intersection Test Queries
+//--------------------------------------------------------------------------------
+
+//--------------------------------------------------------------------------------
+// Closest Points Queries
+//--------------------------------------------------------------------------------
+
+// ****************************************************************************
+// Author: Frank Hart, August 2020
+template<typename T>
+udResult udGeometry_CP3PointPlane(const udVector3<T> &point, const udPlane<T> &plane, udVector3<T> *pOut)
+{
+  udResult result;
+  T signedDistance = {};
+
+  UD_ERROR_NULL(pOut, udR_InvalidParameter);
+
+  signedDistance = udGeometry_SignedDistance(plane, point);
+  *pOut = point - signedDistance * plane.normal;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, June 2020
+template<typename T, int R>
+udResult udGeometry_CPPointLine(const udVector_t &point, const udLine<T, R> &line, udCPPointLineResult<T, R> *pData)
+{
+  udResult result;
+  udVector_t w = {};
+
+  UD_ERROR_NULL(pData, udR_InvalidParameter);
+
+  w = point - line.origin;
+  pData->u = udDot(w, line.direction);
+  pData->point = line.origin + pData->u * line.direction;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, June 2020
+template<typename T, int R>
+udResult udGeometry_CPPointSegment(const udVector_t &point, const udSegment<T, R> &seg, udCPPointSegmentResult<T, R> *pResult)
+{
+  udResult result;
+  udVector_t w = {};
+  udVector_t axis = {};
+  T proj;
+  T vsq;
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  w = point - seg.p0;
+  axis = seg.p1 - seg.p0;
+
+  proj = udDot(w, seg.p1 - seg.p0);
+
+  if (proj <= T(0))
+  {
+    pResult->u = T(0);
+  }
+  else
+  {
+    vsq = udMagSq(axis);
+
+    if (proj >= vsq)
+      pResult->u = T(1);
+    else
+      pResult->u = (proj / vsq);
+  }
+
+  pResult->point = seg.p0 + pResult->u * axis;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, June 2020
+// Based of the work of James M. Van Verth and Lars M. Biship, taken from 'Essential Mathematics for Games and Interactive Applications: A Programmer's Guide, Second Edition
+template<typename T, int R>
+udResult udGeometry_CPLineLine(const udLine<T, R> & line_a, const udLine<T, R> & line_b, udCPLineLineResult<T, R> *pResult)
+{
+  udResult result;
+  udVector_t w0 = {};
+  T a, b, c, d;
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  //compute intermediate parameters
+  w0 = line_a.origin - line_b.origin;
+  a = udDot(line_a.direction, line_b.direction);
+  b = udDot(line_a.direction, w0);
+  c = udDot(line_b.direction, w0);
+  d = static_cast<T>(1) - a*a;
+
+  if (udIsZero(d))
+  {
+    pResult->u_a = static_cast<T>(0);
+    pResult->u_b = c;
+    pResult->code = udGC_Parallel;
+  }
+  else
+  {
+    pResult->u_a = ((a*c - b) / d);
+    pResult->u_b = ((c - a*b) / d);
+    pResult->code = udGC_Success;
+  }
+
+  pResult->cp_a = line_a.origin + pResult->u_a * line_a.direction;
+  pResult->cp_b = line_b.origin + pResult->u_b * line_b.direction;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, November 2021
+// Based of the work of James M. Van Verth and Lars M. Biship, taken from 'Essential Mathematics for Games and Interactive Applications: A Programmer's Guide, Second Edition
+template<typename T, int R>
+udResult udGeometry_CPLineSegment(const udLine<T, R> & line, const udSegment<T, R> & seg, udCPLineSegmentResult<T, R> *pResult)
+{
+  udResult result;
+  udVector_t segDir = seg.Direction();
+  udVector_t w0 = {};
+  T a, b, c, d, denom;
+
+  //compute intermediate parameters
+  w0 = (seg.p0 - line.origin);
+  a = udDot(segDir, segDir);
+  b = udDot(segDir, line.direction);
+  c = udDot(segDir, w0);
+  d = udDot(line.direction, w0);
+  denom = a - b*b;
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  // if denom is zero, try finding closest point on line to segment origin
+  if (udIsZero(denom))
+  {
+    pResult->u_s = static_cast<T>(0);
+    pResult->u_l = d;
+    pResult->code = udGC_Parallel;
+  }
+  else
+  {
+    pResult->code = udGC_Success;
+
+    // clamp pResult.uls within [0,1]
+    T sn = b*d - c;
+
+    // clamp pResult.uls to 0
+    if (sn < static_cast<T>(0))
+    {
+      pResult->u_s = static_cast<T>(0);
+      pResult->u_l = d;
+    }
+    // clamp pResult.uls to 1
+    else if (sn > denom)
+    {
+      pResult->u_s = static_cast<T>(1);
+      pResult->u_l = (d + b);
+    }
+    else
+    {
+      pResult->u_s = sn / denom;
+      pResult->u_l = (a*d - b*c) / denom;
+    }
+  }
+
+  pResult->cp_s = seg.p0 + pResult->u_s*segDir;
+  pResult->cp_l = line.origin + pResult->u_l*line.direction;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, June 2020
+// Based of the work of James M. Van Verth and Lars M. Biship, taken from 'Essential Mathematics for Games and Interactive Applications: A Programmer's Guide, Second Edition
+template<typename T, int R>
+udResult udGeometry_CPSegmentSegment(const udSegment<T, R> &seg_a, const udSegment<T, R> &seg_b, udCPSegmentSegmentResult<T, R> *pResult)
+{
+  udResult result;
+  udVector_t da = {};
+  udVector_t db = {};
+  udVector_t w0 = {};
+  T a, b, c, d, e, denom, sn, sd, tn, td;
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  pResult->code = udGC_Success;
+
+  //directions
+  da = seg_a.p1 - seg_a.p0;
+  db = seg_b.p1 - seg_b.p0;
+
+  //compute intermediate parameters
+  w0 = seg_a.p0 - seg_b.p0;
+  a = udDot(da, da);
+  b = udDot(da, db);
+  c = udDot(db, db);
+  d = udDot(da, w0);
+  e = udDot(db, w0);
+  denom = a*c - b*b;
+
+  // if denom is zero, try finding closest point on segment1 to origin0
+  if (udIsZero(denom))
+  {
+    // clamp pResult->u_a to 0
+    sd = td = c;
+    sn = T(0);
+    tn = e;
+
+    //Do the line segments overlap?
+    udVector3<T> w1((seg_a.p0 + da) - seg_b.p0);
+    udVector3<T> w2(seg_a.p0 - (seg_b.p0 + db));
+    udVector3<T> w3((seg_a.p0 + da) - (seg_b.p0 + db));
+    bool bse = (e < T(0));
+    if (!(bse == (udDot(w1, db) < T(0)) && bse == (udDot(w2, db) < T(0)) && bse == (udDot(w3, db) < T(0))))
+      pResult->code = udGC_Overlapping;
+  }
+  else
+  {
+    // clamp pResult->u_a within [0,1]
+    sd = td = denom;
+    sn = b * e - c * d;
+    tn = a * e - b * d;
+    
+    // clamp pResult->u_a to 0
+    if (sn < T(0))
+    {
+      sn = T(0);
+      tn = e;
+      td = c;
+    }
+    // clamp pResult->u_a to 1
+    else if (sn > sd)
+    {
+      sn = sd;
+      tn = e + b;
+      td = c;
+    }
+  }
+
+  // clamp pResult->u_b within [0,1]
+  // clamp pResult->u_b to 0
+  if (tn < T(0))
+  {
+    pResult->u_b = T(0);
+    // clamp pResult->u_a to 0
+    if (-d < T(0))
+      pResult->u_a = T(0);
+    // clamp pResult->u_a to 1
+    else if (-d > a)
+      pResult->u_a = T(1);
+    else
+      pResult->u_a = -d / a;
+  }
+  // clamp pResult->u_b to 1
+  else if (tn > td)
+  {
+    pResult->u_b = T(1);
+    // clamp pResult->u_a to 0
+    if ((-d + b) < T(0))
+      pResult->u_a = T(0);
+    // clamp pResult->u_a to 1
+    else if ((-d + b) > a)
+      pResult->u_a = T(1);
+    else
+      pResult->u_a = (-d + b) / a;
+  }
+  else
+  {
+    pResult->u_b = tn / td;
+    pResult->u_a = sn / sd;
+  }
+
+  pResult->cp_a = seg_a.p0 + pResult->u_a * da;
+  pResult->cp_b = seg_b.p0 + pResult->u_b * db;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+
+// ****************************************************************************
+// Author: Frank Hart, October 2021
+template<typename T, int R>
+udResult udGeometry_TIPointAABB(const udVector_t &point, const udAABB<T, R> &box, udGeometryCode *pCode)
+{
+  udResult result;
+
+  UD_ERROR_NULL(pCode, udR_InvalidParameter);
+
+  *pCode = udGC_Intersecting;
+  for (int i = 0; i < 3; i++)
+  {
+    if (point[i] < box.minPoint[i] || point[i] > box.maxPoint[i])
+    {
+      *pCode = udGC_NotIntersecting;
+      break;
+    }
+  }
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+
+// ****************************************************************************
+// Author: Frank Hart, October 2021
+template<typename T, int R>
+udResult udGeometry_TIAABBAABB(const udAABB<T, R> &box0, const udAABB<T, R> &box1, udGeometryCode *pCode)
+{
+  udResult result;
+
+  UD_ERROR_NULL(pCode, udR_InvalidParameter);
+
+  *pCode = udGC_Intersecting;
+  for (int i = 0; i < 3; i++)
+  {
+    if (box0.minPoint[i] > box1.maxPoint[i] || box1.minPoint[i] > box0.maxPoint[i])
+    {
+      *pCode = udGC_NotIntersecting;
+      break;
+    }
+  }
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Adapted from "Optimal Reliable Point-in-Polygon Test and Differential Coding Boolean Operations on Polygons"
+// Authors: Jianqiang Hao, Jianzhi Sun, Yi Chen, Qiang Cai and Li Tan
+template<typename T>
+udResult udGeometry_TI2PointPolygon(const udVector2<T> & point, const udVector2<T> * pPoints, size_t count, udGeometryCode * pCode)
+{
+  udResult result;
+
+  size_t k = 0;
+  T f = T(0);
+  T u1 = T(0);
+  T v1 = T(0);
+  T u2 = T(0);
+  T v2 = T(0);
+
+  UD_ERROR_NULL(pPoints, udR_InvalidParameter);
+  UD_ERROR_NULL(pCode, udR_InvalidParameter);
+
+  *pCode = udGC_Success;
+
+  for (size_t i = 0; i < count; i++)
+  {
+    size_t j = (i + 1) % count;
+    T xi = pPoints[i].x;
+    T yi = pPoints[i].y;
+    T xj = pPoints[j].x;
+    T yj = pPoints[j].y;
+
+    v1 = yi - point.y;
+    v2 = yj - point.y;
+
+    if (((v1 < T(0)) && (v2 < T(0))) || ((v1 > T(0)) && (v2 > T(0))))
+      continue;
+
+    u1 = xi - point.x;
+    u2 = xj - point.x;
+
+    if ((v2 > T(0)) && (v1 <= T(0)))
+    {
+      f = u1 * v2 - u2 * v1;
+      if (f > 0)
+      {
+        k++;
+      }
+      else if (f == 0)
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+    }
+    else if ((v1 > T(0)) && (v2 <= T(0)))
+    {
+      f = u1 * v2 - u2 * v1;
+      if (f < 0)
+      {
+        k++;
+      }
+      else if (f == 0)
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+    }
+    else if ((v2 == T(0)) && (v1 < T(0)))
+    {
+      f = u1 * v2 - u2 * v1;
+      if (f == 0)
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+    }
+    else if ((v1 == T(0)) && (v2 < T(0)))
+    {
+      f = u1 * v2 - u2 * v1;
+      if (f == 0)
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+    }
+    else if ((v1 == T(0)) && (v2 == T(0)))
+    {
+      if ((u2 <= T(0)) && (u1 >= T(0)))
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+      else if ((u1 <= T(0)) && (u2 >= T(0)))
+      {
+        *pCode = udGC_OnBoundary;
+        break;
+      }
+    }
+  }
+
+  if (*pCode != udGC_OnBoundary)
+    *pCode = (k % 2 == 0) ? udGC_CompletelyOutside : udGC_CompletelyInside;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+// ****************************************************************************
+// Author: Frank Hart, July 2020
+// Based on Real Time Collision Detection, Christer Ericson p184
+template<typename T>
+udResult udGeometry_FI3SegmentTriangle(const udSegment3<T> &seg, const udTriangle3<T> &tri, udFI3SegmentTriangleResult<T> *pResult)
+{
+  udResult result;
+  int sign;
+  T denom;
+
+  udVector3<T> s0s1 = seg.p1 - seg.p0;
+  udVector3<T> s0t0 = tri.pt.p0 - seg.p0;
+  udVector3<T> s0t1 = tri.pt.p1 - seg.p0;
+  udVector3<T> s0t2 = tri.pt.p2 - seg.p0;
+
+  T u = udGeometry_ScalarTripleProduct(s0s1, s0t2, s0t1);
+  T v = udGeometry_ScalarTripleProduct(s0s1, s0t0, s0t2);
+  T w = udGeometry_ScalarTripleProduct(s0s1, s0t1, s0t0);
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  // TODO Line is on triangle plane
+  if (udIsZero(u) && udIsZero(v) && udIsZero(w))
+  {
+    // Flag as fail for now...
+    UD_ERROR_SET(udR_Failure);
+  }
+
+  sign = 0;
+  sign |= (u < T(0) ? 1 : 0);
+  sign |= (v < T(0) ? 2 : 0);
+  sign |= (w < T(0) ? 4 : 0);
+
+  if (sign > 0 && sign < 7)
+  {
+    pResult->code = udGC_NotIntersecting;
+    UD_ERROR_SET(udR_Success);
+  }
+
+  denom = T(1) / (u + v + w);
+  u *= denom;
+  v *= denom;
+  w *= denom;
+
+  pResult->intersecting.point = u * tri.pt.p0 + v * tri.pt.p1 + w * tri.pt.p2;
+  pResult->code = udGC_Intersecting;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+template<typename T, int R>
+udResult udGeometry_CPPointTriangle(const udVector_t &point, const udTriangle<T, R> &tri, udVector_t *pOut)
+{
+  udResult result;
+  udVector_t v01 = {};
+  udVector_t v02 = {};
+  udVector_t v0p = {};
+  T d1, d2;
+
+  UD_ERROR_NULL(pOut, udR_InvalidParameter);
+
+  v01 = tri.pt.p1 - tri.pt.p0;
+  v02 = tri.pt.p2 - tri.pt.p0;
+  v0p = point - tri.pt.p0;
+
+  d1 = udDot(v01, v0p);
+  d2 = udDot(v02, v0p);
+
+  do
+  {
+    if (d1 <= T(0) && d2 <= T(0))
+    {
+      *pOut = tri.pt.p0;
+      break;
+    }
+
+    udVector3<T> v1p = point - tri.pt.p1;
+    T d3 = udDot(v01, v1p);
+    T d4 = udDot(v02, v1p);
+    if (d3 >= T(0) && d4 <= d3)
+    {
+      *pOut = tri.pt.p1;
+      break;
+    }
+
+    T v2 = d1 * d4 - d3 * d2;
+    if (v2 <= T(0) && d1 >= T(0) && d3 <= T(0))
+    {
+      T v = d1 / (d1 - d3);
+      *pOut = tri.pt.p0 + v * v01;
+      break;
+    }
+
+    udVector3<T> v2p = point - tri.pt.p2;
+    T d5 = udDot(v01, v2p);
+    T d6 = udDot(v02, v2p);
+    if (d6 >= T(0) && d5 <= d6)
+    {
+      *pOut = tri.pt.p2;
+      break;
+    }
+
+    T v1 = d5 * d2 - d1 * d6;
+    if (v1 <= T(0) && d2 >= T(0) && d6 <= T(0))
+    {
+      T w = d2 / (d2 - d6);
+      *pOut = tri.pt.p0 + w * v02;
+      break;
+    }
+
+    T v0 = d3 * d6 - d5 * d4;
+    if (v0 <= T(0) && (d4 - d3) >= T(0) && (d5 - d6) >= T(0))
+    {
+      T w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+      *pOut = tri.pt.p1 + w * (tri.pt.p2 - tri.pt.p1);
+      break;
+    }
+
+    T denom = T(1) / (v0 + v1 + v2);
+    T v = v1 * denom;
+    T w = v2 * denom;
+    *pOut = tri.pt.p0 + v01 * v + v02 * w;
+
+  } while (false);
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+template<typename T>
+udResult udGeometry_FI3RayPlane(const udRay3<T> & ray, const udPlane<T> & plane, udFI3RayPlaneResult<T> * pResult)
+{
+  udResult result;
+  T denom;
+
+  UD_ERROR_NULL(pResult, udR_InvalidParameter);
+
+  denom = udDot(plane.normal, ray.direction);
+
+  //check if ray is parallel to plane
+  if (udIsZero(denom))
+  {
+    pResult->u = T(0);
+
+    //check if ray is on the plane
+    if (udIsZero(udGeometry_SignedDistance(plane, ray.origin)))
+      pResult->code = udGC_Coincident;
+    else
+      pResult->code = udGC_NotIntersecting;
+  }
+  else
+  {
+    pResult->u = (-(udDot(ray.origin, plane.normal) + plane.offset) / denom);
+
+    //ray points away from plane
+    if (pResult->u < T(0))
+    {
+      pResult->code = udGC_NotIntersecting;
+      pResult->u = T(0);
+    }
+    else
+    {
+      pResult->code = udGC_Intersecting;
+    }
+  }
+
+  pResult->point = ray.origin + pResult->u * ray.direction;
+
+  result = udR_Success;
+epilogue:
+  return result;
+}

--- a/Include/udMath.h
+++ b/Include/udMath.h
@@ -116,6 +116,11 @@ template <typename T> udVector2<T> udCeil(const udVector2<T> &v);
 template <typename T> udVector3<T> udCeil(const udVector3<T> &v);
 template <typename T> udVector4<T> udCeil(const udVector4<T> &v);
 
+//floating point tolerance
+template<typename T> constexpr T udGetEpsilon();
+template<> constexpr double udGetEpsilon() { return 1e-12; }
+template<> constexpr float udGetEpsilon() { return 1e-6f; }
+
 // typical linear algebra functions
 template <typename T> T            udAbs(T v);
 template <typename T> udVector2<T> udAbs(const udVector2<T> &v);
@@ -430,34 +435,34 @@ struct udQuaternion
 template <typename T, typename U>
 udQuaternion<T> operator *(U f, const udQuaternion<T> &q) { return q * f; }
 
-template <typename T>
-struct udRay
-{
-  udVector3<T> position;
-  udVector3<T> direction;
+//template <typename T>
+//struct udRay
+//{
+//  udVector3<T> position;
+//  udVector3<T> direction;
+//
+//  // static members
+//  static udRay<T> create(const udVector3<T> &position, const udVector3<T> &direction) { udRay<T> r = { position, direction }; return r; }
+//
+//  template <typename U>
+//  static udRay<T> create(const udRay<U> &_v) { udRay<T> r = { udVector3<T>::create(_v.position), udVector3<T>::create(_v.direction) }; return r; }
+//
+//  static udRay<T> rotationAround(const udRay<T> &ray, const udVector3<T> &center, const udVector3<T> &axis, const T &angle);
+//};
 
-  // static members
-  static udRay<T> create(const udVector3<T> &position, const udVector3<T> &direction) { udRay<T> r = { position, direction }; return r; }
-
-  template <typename U>
-  static udRay<T> create(const udRay<U> &_v) { udRay<T> r = { udVector3<T>::create(_v.position), udVector3<T>::create(_v.direction) }; return r; }
-
-  static udRay<T> rotationAround(const udRay<T> &ray, const udVector3<T> &center, const udVector3<T> &axis, const T &angle);
-};
-
-template <typename T>
-struct udPlane
-{
-  udVector3<T> point;
-  udVector3<T> normal;
-
-  bool intersects(const udRay<T> &ray, udVector3<T> *pIntersectionPoint, T *pIntersectionDistance) const;
-
-  // static members
-  static udPlane<T> create(const udVector3<T> &position, const udVector3<T> &normal) { udPlane<T> r = { position, normal }; return r; }
-  template <typename U>
-  static udPlane<T> create(const udPlane<U> &_v) { udPlane<T> r = { udVector3<T>::create(_v.point), udVector3<T>::create(_v.normal) }; return r; }
-};
+//template <typename T>
+//struct udPlane
+//{
+//  udVector3<T> point;
+//  udVector3<T> normal;
+//
+//  bool intersects(const udRay<T> &ray, udVector3<T> *pIntersectionPoint, T *pIntersectionDistance) const;
+//
+//  // static members
+//  static udPlane<T> create(const udVector3<T> &position, const udVector3<T> &normal) { udPlane<T> r = { position, normal }; return r; }
+//  template <typename U>
+//  static udPlane<T> create(const udPlane<U> &_v) { udPlane<T> r = { udVector3<T>::create(_v.point), udVector3<T>::create(_v.normal) }; return r; }
+//};
 
 template <typename T>
 struct udMatrix4x4

--- a/Include/udMath_Inl.h
+++ b/Include/udMath_Inl.h
@@ -543,47 +543,47 @@ udQuaternion<T> udConjugate(const udQuaternion<T> &q)
   return r;
 }
 
-// udRay members
-template <typename T>
-udRay<T> udRay<T>::rotationAround(const udRay<T> &ray, const udVector3<T> &center, const udVector3<T> &axis, const T &angle)
-{
-  udRay<T> r;
-
-  udQuaternion<T> rotation = udQuaternion<T>::create(axis, angle);
-
-  udVector3<T> direction = ray.position - center; // find current direction relative to center
-  r.position = center + rotation.apply(direction); // define new position
-  r.direction = udDirectionFromYPR((rotation * udQuaternion<T>::create(udDirectionToYPR(ray.direction))).eulerAngles()); // rotate object to keep looking at the center
-
-  return r;
-}
+//// udRay members
+//template <typename T>
+//udRay<T> udRay<T>::rotationAround(const udRay<T> &ray, const udVector3<T> &center, const udVector3<T> &axis, const T &angle)
+//{
+//  udRay<T> r;
+//
+//  udQuaternion<T> rotation = udQuaternion<T>::create(axis, angle);
+//
+//  udVector3<T> direction = ray.position - center; // find current direction relative to center
+//  r.position = center + rotation.apply(direction); // define new position
+//  r.direction = udDirectionFromYPR((rotation * udQuaternion<T>::create(udDirectionToYPR(ray.direction))).eulerAngles()); // rotate object to keep looking at the center
+//
+//  return r;
+//}
 
 // udPlane members
-template <typename T>
-bool udPlane<T>::intersects(const udRay<T> &ray, udVector3<T> *pIntersectionPoint, T *pIntersectionDistance) const
-{
-  udVector3<T> rayDir = ray.direction;
-  udVector3<T> planeRay = point - ray.position;
-
-  T denom = udDot(normal, rayDir);
-  T distance = T(0);
-
-  if (denom == T(0))
-    return false; // Plane is parallel to the ray
-
-  distance = udDot(planeRay, normal) / denom;
-
-  if (distance < T(0))
-    return false; // Behind the ray
-
-  if (pIntersectionPoint)
-    *pIntersectionPoint = ray.position + rayDir * distance;
-
-  if (pIntersectionDistance)
-    *pIntersectionDistance = distance;
-
-  return true;
-}
+//template <typename T>
+//bool udPlane<T>::intersects(const udRay<T> &ray, udVector3<T> *pIntersectionPoint, T *pIntersectionDistance) const
+//{
+//  udVector3<T> rayDir = ray.direction;
+//  udVector3<T> planeRay = point - ray.position;
+//
+//  T denom = udDot(normal, rayDir);
+//  T distance = T(0);
+//
+//  if (denom == T(0))
+//    return false; // Plane is parallel to the ray
+//
+//  distance = udDot(planeRay, normal) / denom;
+//
+//  if (distance < T(0))
+//    return false; // Behind the ray
+//
+//  if (pIntersectionPoint)
+//    *pIntersectionPoint = ray.position + rayDir * distance;
+//
+//  if (pIntersectionDistance)
+//    *pIntersectionDistance = distance;
+//
+//  return true;
+//}
 
 // udMatrix4x4 members
 template <typename T>

--- a/udTest/src/udGeometryTests.cpp
+++ b/udTest/src/udGeometryTests.cpp
@@ -1,0 +1,815 @@
+#include "udGeometryTools.h"
+#include "gtest/gtest.h"
+#include "udPlatform.h"
+
+#define EXPECT_VEC3_NEAR(v0, v1, e) EXPECT_NEAR(v0.x, v1.x, e);\
+EXPECT_NEAR(v0.y, v1.y, e);\
+EXPECT_NEAR(v0.z, v1.z, e)
+
+TEST(GeometryTests, GeometryUtility)
+{
+  EXPECT_EQ(udQuickPowd<4>(2.0), 16.0);
+  EXPECT_EQ(udQuickPowf<16>(2.0), 65536.f);
+
+  double a = 2.0, b = 1.0;
+  udGeometry_SortLowToHigh(a, b);
+  EXPECT_EQ(a, 1.0);
+  EXPECT_EQ(b, 2.0);
+  
+  udInt3 arr = {3, 2, 1};
+  EXPECT_EQ(udGeometry_SortLowToHigh(arr), udInt3::create(1, 2, 3));
+  EXPECT_EQ((udGeometry_Sum<int32_t, 3>(arr)), 6);
+}
+
+TEST(GeometryTests, GeometryConstruction)
+{
+  udPlane<double> plane = {};
+  EXPECT_EQ(plane.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(plane.Set({1.0, 2.0, 3.0}, {0.0, 0.0, 0.0}), udR_Failure);
+
+  EXPECT_EQ(plane.Set({1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}), udR_Success);
+  EXPECT_EQ(plane.Set({1.0, 1.0, 1.0}, {2.0, 2.0, 2.0}, {3.0, 3.0, 3.0}), udR_Failure);
+
+  udAABB3<double> aabb = {};
+  EXPECT_EQ(aabb.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(aabb.Set({1.0, 2.1, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+
+  udSegment3<double> seg = {};
+  EXPECT_EQ(seg.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(seg.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+
+  udLine3<double> line = {};
+  EXPECT_EQ(line.SetFromEndPoints({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(line.SetFromEndPoints({1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+
+  EXPECT_EQ(line.SetFromDirection({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(line.SetFromDirection({1.0, 2.0, 3.0}, {0.0, 0.0, 0.0}), udR_Failure);
+
+  udRay3<double> ray = {};
+  EXPECT_EQ(ray.SetFromEndPoints({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(ray.SetFromEndPoints({1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+
+  EXPECT_EQ(ray.SetFromDirection({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Success);
+  EXPECT_EQ(ray.SetFromDirection({1.0, 2.0, 3.0}, {0.0, 0.0, 0.0}), udR_Failure);
+  
+  udSphere<double> sphere = {};
+  EXPECT_EQ(sphere.Set({0.0, 0.0, 0.0}, 1.0), udR_Success);
+  EXPECT_EQ(sphere.Set({0.0, 0.0, 0.0}, 0.0), udR_Failure);
+  EXPECT_EQ(sphere.Set({0.0, 0.0, 0.0}, -1.0), udR_Failure);
+
+  udTriangle3<double> tri = {};
+  EXPECT_EQ(tri.Set({1.1, 2.0, 3.0}, {1.0, 2.1, 3.1}, {1.0, 2.0, 3.2}), udR_Success);
+  EXPECT_EQ(tri.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}, {1.0, 2.0, 3.2}), udR_Failure);
+  EXPECT_EQ(tri.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+  EXPECT_EQ(tri.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}), udR_Failure);
+  EXPECT_EQ(tri.Set({1.0, 2.0, 3.0}, {1.0, 2.0, 3.1}, {1.0, 2.0, 3.0}), udR_Failure);
+  EXPECT_EQ(tri.Set({1.0, 2.0, 3.1}, {1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}), udR_Failure);
+}
+
+TEST(GeometryTests, Query_Ray_Plane)
+{
+  udFI3RayPlaneResult<double> result = {};
+  udPlane<double> plane = {};
+  udRay3<double> ray = {};
+
+  EXPECT_EQ(ray.SetFromDirection({1.0, 2.0, 3.0}, {1.0, 0.0, 0.0}), udR_Success);
+
+  //Ray not intersecting plane, pointing away from plane
+  EXPECT_EQ(plane.Set({-1.0, 0.0, 0.0}, {-1.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3RayPlane(ray, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+  EXPECT_EQ(result.u, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(result.point, ray.origin)));
+
+  //Ray not intersecting plane, parallel to plane
+  EXPECT_EQ(plane.Set({0.0, 1.0, 0.0}, {0.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3RayPlane(ray, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+  EXPECT_EQ(result.u, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(result.point, ray.origin)));
+
+  //Ray lies on the plane
+  EXPECT_EQ(plane.Set({1.0, 2.0, 3.0}, {0.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3RayPlane(ray, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Coincident);
+  EXPECT_EQ(result.u, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(result.point, ray.origin)));
+
+  //Ray intersects plane
+  EXPECT_EQ(plane.Set({3.0, 0.0, 0.0}, {1.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3RayPlane(ray, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Intersecting);
+  EXPECT_EQ(result.u, 2.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(result.point, udDouble3::create(3.0, 2.0, 3.0))));
+
+  //Ray intersects plane
+  EXPECT_EQ(plane.Set({6.0, 2.3, -5.6}, {-1.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3RayPlane(ray, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Intersecting);
+  EXPECT_EQ(result.u, 5.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(result.point, udDouble3::create(6.0, 2.0, 3.0))));
+}
+TEST(GeometryTests, Query_Segment_Plane)
+{
+  udFI3SegmentPlaneResult<double> result = {};
+  udPlane<double> plane = {};
+  udSegment3<double> seg = {};
+
+  EXPECT_EQ(plane.Set({0.0, 0.0, 1.0}, {0.0, 0.0, 1.0}), udR_Success);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, -2.0}, {0.0, 0.0, -1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, -1.0}, {0.0, 0.0, -2.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, 2.0}, {0.0, 0.0, 3.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, 3.0}, {0.0, 0.0, 2.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_NotIntersecting);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, 0.0}, {0.0, 0.0, 2.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Intersecting);
+  EXPECT_EQ(result.u, 0.5);
+
+  EXPECT_EQ(seg.Set({0.0, 0.0, 2.0}, {0.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Intersecting);
+  EXPECT_EQ(result.u, 0.5);
+
+  EXPECT_EQ(seg.Set({1.0, 1.0, 1.0}, {2.0, 2.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentPlane(seg, plane, &result), udR_Success);
+  EXPECT_EQ(result.code, udGC_Coincident);
+  EXPECT_EQ(result.u, 0.0);
+  EXPECT_EQ(result.point, seg.p0);
+}
+
+TEST(GeometryTests, Query_Point_Line)
+{
+  udLine3<double> line;
+  EXPECT_EQ(line.SetFromDirection({1.0, 1.0, 1.0}, {1.0, 0.0, 0.0}), udR_Success);
+  udCPPointLineResult<double, 3> cpResult ={};
+  udDouble3 point ={};
+
+  //Point lies 'before' line origin
+  point ={-3.0, 1.0, 2.0};
+  EXPECT_EQ(udGeometry_CPPointLine(point, line, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.u, -4.0);
+  EXPECT_EQ(cpResult.point, udDouble3::create(-3.0, 1.0, 1.0));
+
+  //Point lies perpendicular to line origin
+  point ={1.0, 1.0, 2.0};
+  EXPECT_EQ(udGeometry_CPPointLine(point, line, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.u, 0.0);
+  EXPECT_EQ(cpResult.point, udDouble3::create(1.0, 1.0, 1.0));
+
+  //Point lies 'after' line origin
+  point ={7.0, 1.0, 2.0};
+  EXPECT_EQ(udGeometry_CPPointLine(point, line, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.u, 6.0);
+  EXPECT_EQ(cpResult.point, udDouble3::create(7.0, 1.0, 1.0));
+}
+
+TEST(GeometryTests, Query_Line_Line)
+{
+  udLine3<double> line_a ={};
+  udLine3<double> line_b ={};
+  udCPLineLineResult<double, 3> cpResult ={};
+
+  EXPECT_EQ(line_a.SetFromDirection({0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}), udR_Success);
+
+  //Lines coincident
+  EXPECT_EQ(line_b.SetFromDirection({42.0, 0.0, 0.0}, {-1.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_CPLineLine(line_a, line_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Parallel);
+  EXPECT_EQ(cpResult.cp_a, line_a.origin);
+  EXPECT_EQ(cpResult.cp_b, line_a.origin);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 42.0);
+
+  //Lines parallel
+  EXPECT_EQ(line_b.SetFromDirection({42.0, 1.0, 1.0}, {1.0, 0.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_CPLineLine(line_a, line_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Parallel);
+  EXPECT_EQ(cpResult.cp_a, line_a.origin);
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(0.0, 1.0, 1.0));
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, -42.0);
+
+  //Lines not parallel
+  EXPECT_EQ(line_b.SetFromDirection({42.0, 0.0, 1.0}, {0.0, 0.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_CPLineLine(line_a, line_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.cp_a, udDouble3::create(42.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(42.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.u_a, 42.0);
+  EXPECT_EQ(cpResult.u_b, -1.0);
+}
+
+TEST(GeometryTests, Query_Line_Segment)
+{
+  udCPLineSegmentResult<double, 3> cpLineSegmentResult;
+  udSegment<double, 3> seg ={};
+  udLine3<double> line;
+
+  seg.Set({2.0, 0.0, 0.0}, {6.0, 0.0, 0.0});
+
+  //Segment and line coincident
+  line.SetFromDirection({13.0, 0.0, 0.0}, {1.0, 0.0, 0.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Parallel);
+  EXPECT_EQ(cpLineSegmentResult.u_l, -11.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, seg.p0)));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(2.0, 0.0, 0.0))));
+
+  //Segment parallel to line
+  line.SetFromDirection({3.0, 3.0, 4.0}, {1.0, 0.0, 0.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Parallel);
+  EXPECT_EQ(cpLineSegmentResult.u_l, -1.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, seg.p0)));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(2.0, 3.0, 4.0))));
+
+  //Segment parallel to line, opposite direction
+  line.SetFromDirection({3.0, 3.0, 4.0}, {-1.0, 0.0, 0.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Parallel);
+  EXPECT_EQ(cpLineSegmentResult.u_l, 1.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, seg.p0)));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(2.0, 3.0, 4.0))));
+
+  //Segment-p0 closest point
+  line.SetFromDirection({-1.0, 4.0, 3.0}, {0.0, 0.0, -1.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Success);
+  EXPECT_EQ(cpLineSegmentResult.u_l, 3.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 0.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, seg.p0)));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(-1.0, 4.0, 0.0))));
+
+  //Segment-p1 closest point
+  line.SetFromDirection({9.0, 4.0, 3.0}, {0.0, 0.0, -1.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Success);
+  EXPECT_EQ(cpLineSegmentResult.u_l, 3.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 1.0);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, seg.p1)));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(9.0, 4.0, 0.0))));
+
+  //Closest point along Segment
+  line.SetFromDirection({3.0, 4.0, 3.0}, {0.0, 0.0, 1.0});
+  EXPECT_EQ(udGeometry_CPLineSegment(line, seg, &cpLineSegmentResult), udR_Success);
+  EXPECT_EQ(cpLineSegmentResult.code, udGC_Success);
+  EXPECT_EQ(cpLineSegmentResult.u_l, -3.0);
+  EXPECT_EQ(cpLineSegmentResult.u_s, 0.25);
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_s, udDouble3::create(3.0, 0.0, 0.0))));
+  EXPECT_TRUE((udAreEqual<double, 3>(cpLineSegmentResult.cp_l, udDouble3::create(3.0, 4.0, 0.0))));
+}
+
+TEST(GeometryTests, Query_Point_Segment)
+{
+  udSegment<double, 3> seg ={};
+  udCPPointSegmentResult<double, 3> cpPointSegmentResult ={};
+  udDouble3 point ={};
+
+  //Point lies 'before' segment 0
+  seg.Set({1.0, 1.0, 1.0}, {3.0, 1.0, 1.0});
+  point ={-1.0, 1.0, 1.0};
+  EXPECT_EQ(udGeometry_CPPointSegment(point, seg, &cpPointSegmentResult), udR_Success);
+  EXPECT_EQ(cpPointSegmentResult.u, 0.0);
+  EXPECT_EQ(cpPointSegmentResult.point, seg.p0);
+
+  //Point lies 'after' segment 1
+  point ={5.0, 1.0, 1.0};
+  EXPECT_EQ(udGeometry_CPPointSegment(point, seg, &cpPointSegmentResult), udR_Success);
+  EXPECT_EQ(cpPointSegmentResult.u, 1.0);
+  EXPECT_EQ(cpPointSegmentResult.point, seg.p1);
+
+  //Point lies along the segment line
+  point ={2.0, 10.0, 42.0};
+  EXPECT_EQ(udGeometry_CPPointSegment(point, seg, &cpPointSegmentResult), udR_Success);
+  EXPECT_EQ(cpPointSegmentResult.u, 0.5);
+  EXPECT_EQ(cpPointSegmentResult.point, udDouble3::create(2.0, 1.0, 1.0));
+}
+
+TEST(GeometryTests, Query_Segment_Segment)
+{
+  udSegment<double, 3> seg_a = {};
+  udSegment<double, 3> seg_b = {};
+  udCPSegmentSegmentResult<double, 3> cpResult = {};
+
+  seg_a.p0 = {2.0, 0.0, 0.0};
+  seg_a.p1 = {6.0, 0.0, 0.0};
+
+  //Segments parallel, no overlap, closest points a0, seg_b.p0
+  seg_b.p0 = {-1.0, -4.0, 12.0};
+  seg_b.p1 = {-5.0, -4.0, 12.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments parallel, no overlap, closest points a0, seg_b.p1
+  seg_b.p0 = {-5.0, -4.0, 12.0};
+  seg_b.p1 = {-1.0, -4.0, 12.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 1.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p1);
+
+  //Segments parallel, no overlap, closest points a1, seg_b.p0
+  seg_b.p0 = {9.0, -4.0, 12.0};
+  seg_b.p1 = {18.0, -4.0, 12.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 1.0);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p1);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments parallel, no overlap, closest points a1, seg_b.p1
+  seg_b.p0 = {10.0, -4.0, 12.0};
+  seg_b.p1 = {9.0, -4.0, 12.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 1.0);
+  EXPECT_EQ(cpResult.u_b, 1.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p1);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p1);
+
+  //Segments parallel, overlap, a0---seg_b.p0---a1---seg_b.p1
+  seg_b.p0 = {4.0, -3.0, 4.0};
+  seg_b.p1 = {10.0, -3.0, 4.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  //Why udQCOverlapping and not udQC_Parallel? Because overlapping segments are already parallel.
+  EXPECT_EQ(cpResult.code, udGC_Overlapping);
+  EXPECT_EQ(cpResult.u_a, 0.5);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, udDouble3::create(4.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments parallel, overlap, a1---seg_b.p0---a0---seg_b.p1
+  seg_b.p0 = {4.0, -3.0, 4.0};
+  seg_b.p1 = {0.0, -3.0, 4.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Overlapping);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 0.5);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(2.0, -3.0, 4.0));
+
+  //Segments parallel, overlap, a0---seg_b.p0---seg_b.p1---a1
+  seg_b.p0 = {4.0, -3.0, 4.0};
+  seg_b.p1 = {5.0, -3.0, 4.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Overlapping);
+  EXPECT_EQ(cpResult.u_a, 0.5);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, udDouble3::create(4.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments parallel, overlap, a1---seg_b.p0---seg_b.p1---a0
+  seg_b.p0 = {4.0, -3.0, 4.0};
+  seg_b.p1 = {8.0, -3.0, 4.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Overlapping);
+  EXPECT_EQ(cpResult.u_a, 0.5);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, udDouble3::create(4.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments not parallel, closest points: a0, seg_b.p0
+  seg_b.p0 = {-2.0, -5.0, 20.0};
+  seg_b.p1 = {-2.0, -5.0, 23.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments not parallel, closest points: a0, seg_b.p1
+  seg_b.p0 = {-2.0, -5.0, 23.0};
+  seg_b.p1 = {-2.0, -5.0, 20.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 1.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p1);
+
+  //Segments not parallel, closest points: a1, seg_b.p0
+  seg_b.p0 = {10.0, -5.0, 20.0};
+  seg_b.p1 = {10.0, -5.0, 23.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 1.0);
+  EXPECT_EQ(cpResult.u_b, 0.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p1);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p0);
+
+  //Segments not parallel, closest points: a1, seg_b.p1
+  seg_b.p0 = {10.0, -5.0, 23.0};
+  seg_b.p1 = {10.0, -5.0, 20.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 1.0);
+  EXPECT_EQ(cpResult.u_b, 1.0);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p1);
+  EXPECT_EQ(cpResult.cp_b, seg_b.p1);
+
+  //Segments not parallel, closest points: a0, ls1-along ls
+  seg_b.p0 = {-1.0, 4.0, -3.0};
+  seg_b.p1 = {-1.0, 4.0, 3.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.0);
+  EXPECT_EQ(cpResult.u_b, 0.5);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p0);
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(-1.0, 4.0, 0.0));
+
+  //Segments not parallel, closest points: a1, ls1-along ls
+  seg_b.p0 = {9.0, 4.0, -3.0};
+  seg_b.p1 = {9.0, 4.0, 3.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 1.0);
+  EXPECT_EQ(cpResult.u_b, 0.5);
+  EXPECT_EQ(cpResult.cp_a, seg_a.p1);
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(9.0, 4.0, 0.0));
+
+  //Segments not parallel, closest points: ls0-along ls, ls1-along ls
+  seg_b.p0 = {4.0, 4.0, -3.0};
+  seg_b.p1 = {4.0, -4.0, -3.0};
+  EXPECT_EQ(udGeometry_CPSegmentSegment(seg_a, seg_b, &cpResult), udR_Success);
+  EXPECT_EQ(cpResult.code, udGC_Success);
+  EXPECT_EQ(cpResult.u_a, 0.5);
+  EXPECT_EQ(cpResult.u_b, 0.5);
+  EXPECT_EQ(cpResult.cp_a, udDouble3::create(4.0, 0.0, 0.0));
+  EXPECT_EQ(cpResult.cp_b, udDouble3::create(4.0, 0.0, -3.0));
+}
+
+TEST(GeometryTests, GeometryEquivalence)
+{
+  EXPECT_TRUE(udAreEqual<double>(1.0, 1.0));
+  EXPECT_TRUE(udAreEqual<double>(1.0, 1.0 + udGetEpsilon<double>() * 0.5));
+
+  EXPECT_FALSE(udAreEqual<double>(2.0, 3.0));
+  EXPECT_FALSE(udAreEqual<double>(2.0, 2.0 + udGetEpsilon<double>() * 1.5));
+
+  udDouble3 a = {1.0, 2.0, 3.0};
+  udDouble3 b = {1.01, 2.01, 3.01};
+
+  EXPECT_TRUE((udAreEqual<double, 3>(a, a)));
+  EXPECT_FALSE((udAreEqual<double, 3>(a, b)));
+}
+
+bool CheckBarycentricResult(udTriangle<double, 3> tri, udDouble3 p, udDouble3 uvw)
+{
+  double epsilon = 0.01;
+  udDouble3 out = {};
+  udResult result = udGeometry_Barycentric(tri, p, &out);
+  if (result != udR_Success)
+    return false;
+
+  return udMag(uvw - out) < epsilon;
+}
+
+//Compared with results from https: //www.geogebra.org/m/ZuvmPjmy
+TEST(GeometryTests, GeometryBaryCentric)
+{
+  double a = 1.0;
+  double b = udSqrt(3.0) / 2.0;
+  double c = 0.5;
+
+  udDouble3 t0 = {0.0, a, 0.0};
+  udDouble3 t1 = {b, -c, 0.0};
+  udDouble3 t2 = {-b, -c, 0.0};
+
+  udTriangle<double, 3> tri = {t0, t1, t2};
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 0.0, 0.0}, {0.33, 0.33, 0.33}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 0.0, 345.0}, {0.33, 0.33, 0.33}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 0.0, -327}, {0.33, 0.33, 0.33}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {1.0, 1.0, 0.0}, {1.0, 0.58, -0.58}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {1.0, 1.0, 345.0}, {1.0, 0.58, -0.58}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {1.0, 1.0, -327}, {1.0, 0.58, -0.58}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 1.0, 345.0}, {1.0, 0.0, 0.0}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 1.0, -327}, {1.0, 0.0, 0.0}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 2.0, 0.0}, {1.67, -0.33, -0.33}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 2.0, 345.0}, {1.67, -0.33, -0.33}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, 2.0, -327}, {1.67, -0.33, -0.33}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {-1.0, 1.0, 0.0}, {1.0, -0.58, 0.58}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {-1.0, 1.0, 345.0}, {1.0, -0.58, 0.58}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {-1.0, 1.0, -327}, {1.0, -0.58, 0.58}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, -1.0, 0.0}, {-0.33, 0.67, 0.67}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, -1.0, 345.0}, {-0.33, 0.67, 0.67}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.0, -1.0, -327}, {-0.33, 0.67, 0.67}));
+
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.2, 0.2, 0.0}, {0.47, 0.38, 0.15}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.2, 0.2, 345.0}, {0.47, 0.38, 0.15}));
+  EXPECT_TRUE(CheckBarycentricResult(tri, {0.2, 0.2, -327}, {0.47, 0.38, 0.15}));
+}
+
+bool AreEqual(udPlane<double> p0, udPlane<double> p1)
+{
+  return udAreEqual<double, 3>(p0.normal, p1.normal) && udAreEqual(p0.offset, p1.offset);
+}
+
+TEST(GeometryTests, Planes)
+{
+  typedef udPlane<double> udDoublePlane;
+  udDoublePlane plane0 = {};
+  udDoublePlane plane1 = {};
+
+  // Creation
+  {
+    EXPECT_EQ(plane0.Set({1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 1.0, 1.0}), udR_Success);
+    plane1.normal = {1.0, 0.0, 0.0};
+    plane1.offset = -1.0;
+    EXPECT_TRUE(AreEqual(plane0, plane1));
+
+    EXPECT_EQ(plane0.Set({1.0, 1.0, 1.0}, {1.0, 0.0, 0.0}), udR_Success);
+    EXPECT_TRUE(AreEqual(plane0, plane1));
+
+    EXPECT_EQ(plane0.Set({1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}), udR_Failure);
+  }
+
+  // Distance fom point to plane
+  {
+    plane0.Set({1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 1.0, 1.0});
+
+    EXPECT_EQ(udGeometry_SignedDistance(plane0, {42.0, 1.0, 1.0}), 41.0);
+    EXPECT_EQ(udGeometry_SignedDistance(plane0, {-42.0, 1.0, 1.0}), -43.0);
+    EXPECT_EQ(udGeometry_SignedDistance(plane0, {1.0, 1.0, 1.0}), .0);
+  }
+}
+
+// TODO this needs many more tests!
+TEST(GeometryTests, Query_Point_Triangle)
+{
+  udDouble3 cp = {};
+  udTriangle<double, 3> tri = {};
+  udDouble3 point = {2.0, 0.0, 0.5};
+
+  EXPECT_EQ(tri.Set({1.0, -1.0, -1.0}, {1.0, 1.0, -1.0}, {1.0, 0.0, 10.0}), udR_Success);
+  EXPECT_EQ(udGeometry_CPPointTriangle(point, tri, &cp), udR_Success);
+  EXPECT_EQ(cp, udDouble3::create(1.0, 0.0, 0.5));
+}
+
+TEST(GeometryTests, Query_Point_Polygon)
+{
+  // Point in triangle
+  {
+    udGeometryCode code;
+    udDouble2 points[] ={{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 0.0}};
+    udDouble2 point ={0.0, 0.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyInside);
+  }
+
+  // Point outside triangle
+  {
+    udGeometryCode code;
+    udDouble2 points[] ={{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 0.0}};
+    udDouble2 point ={2.0, 1.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyOutside);
+  }
+
+  // Point in triangle, point aligned with triangle vertex
+  {
+    udGeometryCode code;
+    udDouble2 points[] ={{-1.0, 0.0}, {1.0, 1.0}, {1.0, -1.0}};
+    udDouble2 point ={0.0, 0.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyInside);
+  }
+
+  // Point in triangle, point aligned with triangle vertices
+  {
+    udGeometryCode code;
+    udDouble2 points[] =
+    {
+      {-3.0, 0.0}, {-1.0, 0.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-3.0, -1.0}
+    };
+    udDouble2 point ={0.0, 0.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyInside);
+  }
+
+  // Point in triangle, point aligned with triangle vertices
+  {
+    udGeometryCode code;
+    udDouble2 points[] =
+    {
+      {-3.0, 0.0}, {-2.0, 0.0}, {-1.0, 0.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-3.0, -1.0}
+    };
+    udDouble2 point ={0.0, 0.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyInside);
+  }
+
+  {
+    udGeometryCode code;
+    udDouble2 points[] =
+    {
+      {-334.89, -373.76}, {-335.37, -371.04}, {-337.69, -371.28}, {-337.39, -372.97}
+    };
+    udDouble2 point ={-336.5, -372.0};
+    EXPECT_EQ(udGeometry_TI2PointPolygon(point, points, UDARRAYSIZE(points), &code), udR_Success);
+    EXPECT_EQ(code, udGC_CompletelyInside);
+  }
+}
+TEST(GeometryTests, Query_Segment_Triangle)
+{
+  udTriangle3<double> tri = {};
+  udSegment3<double> seg = {};
+  udFI3SegmentTriangleResult<double> data = {};
+
+  //------------------------------------------------------------------------
+  // Intersecting
+  //------------------------------------------------------------------------
+
+  EXPECT_EQ(seg.Set({0.5, 0.5, 1.0}, {0.5, 0.5, -1.0}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, -1.0, 0.0}, {-1.0, 1.0, 0.0}, {1.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.5, 0.5, 0.0))));
+
+  EXPECT_EQ(seg.Set({0.5, 0.5, 1.0}, {0.5, 0.5, -1.0}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, -1.0, 0.0}, {1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.5, 0.5, 0.0))));
+
+  EXPECT_EQ(seg.Set({0.5, 0.5, -1.0}, {0.5, 0.5, 1.0}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, -1.0, 0.0}, {-1.0, 1.0, 0.0}, {1.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.5, 0.5, 0.0))));
+
+  EXPECT_EQ(seg.Set({0.5, 0.5, -1.0}, {0.5, 0.5, 1.0}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, -1.0, 0.0}, {1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.5, 0.5, 0.0))));
+
+  EXPECT_EQ(seg.Set({-2.0, -0.25, 0.25}, {2.0, -0.25, 0.25}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, 0.0, -1.0}, {0.0, -1.0, 1.0}, {0.0, 1.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.0, -0.25, 0.25))));
+
+  EXPECT_EQ(seg.Set({-2.0, -0.25, 0.25}, {2.0, -0.25, 0.25}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, 0.0, -1.0}, {0.0, 1.0, 1.0}, {0.0, -1.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.0, -0.25, 0.25))));
+
+  EXPECT_EQ(seg.Set({2.0, -0.25, 0.25}, {-2.0, -0.25, 0.25}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, 0.0, -1.0}, {0.0, -1.0, 1.0}, {0.0, 1.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.0, -0.25, 0.25))));
+
+  EXPECT_EQ(seg.Set({2.0, -0.25, 0.25}, {-2.0, -0.25, 0.25}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, 0.0, -1.0}, {0.0, 1.0, 1.0}, {0.0, -1.0, 1.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_Intersecting);
+  EXPECT_TRUE((udAreEqual<double, 3>(data.intersecting.point, udDouble3::create(0.0, -0.25, 0.25))));
+
+  //------------------------------------------------------------------------
+  // Non intersecting
+  //------------------------------------------------------------------------
+  EXPECT_EQ(seg.Set({10.0, 0.5, 1.0}, {10.0, 0.5, -1.0}), udR_Success);
+  EXPECT_EQ(tri.Set({0.0, -1.0, 0.0}, {-1.0, 1.0, 0.0}, {1.0, 1.0, 0.0}), udR_Success);
+  EXPECT_EQ(udGeometry_FI3SegmentTriangle(seg, tri, &data), udR_Success);
+  EXPECT_EQ(data.code, udGC_NotIntersecting);
+
+}
+
+TEST(GeometryTests, GeometryTrianglesGeneral)
+{
+  {
+    udDouble3 t0 = {1.0, 0.0, 0.0};
+    udDouble3 t1 = {udCos(120.0 / 180.0 * UD_PI), udSin(120.0 / 180.0 * UD_PI), 0.0};
+    udDouble3 t2 = {udCos(240.0 / 180.0 * UD_PI), udSin(240.0 / 180.0 * UD_PI), 0.0};
+    double side = 2.0 * udCos(30.0 / 180.0 * UD_PI);
+    double area = udSqrt(3.0) * side * side / 4.0;
+
+    udTriangle3<double> tri = {t0, t1, t2};
+
+    udDouble3 sideLengths = tri.GetSideLengths();
+    EXPECT_TRUE((udAreEqual<double, 3>(sideLengths, udDouble3::create(side, side, side))));
+
+    EXPECT_TRUE((udAreEqual<double>(tri.GetArea(), area)));
+    EXPECT_TRUE((udAreEqual<double>(tri.GetArea(), area)));
+  }
+
+  {
+    udDouble2 t0 = {1.0, 0.0};
+    udDouble2 t1 = {udCos(120.0 / 180.0 * UD_PI), udSin(120.0 / 180.0 * UD_PI)};
+    udDouble2 t2 = {udCos(240.0 / 180.0 * UD_PI), udSin(240.0 / 180.0 * UD_PI)};
+    double side = 2.0 * udCos(30.0 / 180.0 * UD_PI);
+    double area = udSqrt(3.0) * side * side / 4.0;
+
+    udTriangle2<double> tri = {t0, t1, t2};
+
+    udDouble3 sideLengths = tri.GetSideLengths();
+    EXPECT_TRUE((udAreEqual<double, 3>(sideLengths, udDouble3::create(side, side, side))));
+
+    EXPECT_TRUE((udAreEqual<double>(tri.GetArea(), area)));
+    EXPECT_TRUE((udAreEqual<double>(tri.GetArea(), area)));
+  }
+}
+
+TEST(GeometryTests, Query_Point_AABB)
+{
+  udAABB3<double> aabb ={};
+  udGeometryCode code = udGC_Success;
+  EXPECT_EQ(aabb.Set({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0}), udR_Success);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({0.0, 0.0, 0.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_Intersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({-2.0, 0.0, 0.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({2.0, 0.0, 0.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({0.0, -2.0, 0.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({0.0, 2.0, 0.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({0.0, 0.0, -2.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(udGeometry_TIPointAABB({0.0, 0.0, 2.0}, aabb, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+}
+
+TEST(GeometryTests, Query_AABB_AABB)
+{
+  udAABB3<double> aabb0 ={};
+  udAABB3<double> aabb1 ={};
+  udGeometryCode code = udGC_Success;
+
+  EXPECT_EQ(aabb0.Set({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0}), udR_Success);
+  EXPECT_EQ(aabb1.Set({2.0, 2.0, 2.0}, {3.0, 3.0, 3.0}), udR_Success);
+
+  EXPECT_EQ(udGeometry_TIAABBAABB(aabb0, aabb1, &code), udR_Success);
+  EXPECT_EQ(code, udGC_NotIntersecting);
+
+  EXPECT_EQ(aabb1.Set({1.0, 0.0, 0.0}, {3.0, 3.0, 3.0}), udR_Success);
+  EXPECT_EQ(udGeometry_TIAABBAABB(aabb0, aabb1, &code), udR_Success);
+  EXPECT_EQ(code, udGC_Intersecting);
+
+  EXPECT_EQ(aabb1.Set({0.0, 0.0, 0.0}, {3.0, 3.0, 3.0}), udR_Success);
+  EXPECT_EQ(udGeometry_TIAABBAABB(aabb0, aabb1, &code), udR_Success);
+  EXPECT_EQ(code, udGC_Intersecting);
+}
+
+TEST(GeometryTests, GeometryAABB)
+{
+  // Merging AABB
+  {
+    udAABB3<double> aabb0 = {};
+    udAABB3<double> aabb1 = {};
+
+    EXPECT_EQ(aabb0.Set({0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}), udR_Success);
+    EXPECT_EQ(aabb1.Set({-1.0, -2.0, -1.0}, {1.0, 2.0, 0.0}), udR_Success);
+
+    aabb0.Merge(aabb1);
+
+    EXPECT_EQ(aabb0.minPoint.x, -1.0);
+    EXPECT_EQ(aabb0.minPoint.y, -2.0);
+    EXPECT_EQ(aabb0.minPoint.z, -1.0);
+
+    EXPECT_EQ(aabb0.maxPoint.x, 1.0);
+    EXPECT_EQ(aabb0.maxPoint.y, 2.0);
+    EXPECT_EQ(aabb0.maxPoint.z, 1.0);
+  }
+}


### PR DESCRIPTION
I've been maintaining a branch of udCore with additional geometry tools and tests. I've been gradually adding to this library as needed, and is time to pass it on.

The purpose of this PR is not necessarily to add _this_ code to master (although I think we should consider it :) ), but more to start a conversation about what a geometry library might look like, if we should even start one.

I've spent a bit of time in udStream and the SDK fixing geometry code that could have just been pulled from a library, already tested and good to go. And I've also worked on at least two projects (Solidscan, CCTV) which required a few standard geometry intersection tests. Also, there is also nothing special about much of the geometry code in the SDK filter system; much of this code is comprised of standard geometry predicates that could have also be pulled from the one library.

We should only add to the library as needed. And I think it's good exercise for the programmer to recognise reusable geometry abstractions and methods. This stuff is so easy to get wrong, it might be a good idea to have a single module with common geometry predicates tested and ready to go.