### PR TITLE
Fixed bug in udFile where the file length wasn't updated

### DIFF
--- a/Source/udFile.cpp
+++ b/Source/udFile.cpp
@@ -373,6 +373,7 @@ udResult udFile_Write(udFile *pFile, const void *pBuffer, size_t bufferLength, i
   pFile->msAccumulator -= udGetTimeMs();
   result = pFile->fpWrite(pFile, pBuffer, bufferLength, offset, &actualWritten);
   pFile->filePos = offset + actualWritten;
+  pFile->fileLength = udMax(pFile->fileLength, pFile->filePos);
 
   // Update the performance stats unless it's a supported pipelined request (in which case the stats are updated in the block function)
   udUpdateFilePerformance(pFile, actualWritten);


### PR DESCRIPTION
Fixed bug in udFile where the file length wasn't updated in writes that appended to the file, preventing files from being appended to multiple times