### PR TITLE
Added function to set a string more conveniently

### DIFF
--- a/Docs/udJSON.md
+++ b/Docs/udJSON.md
@@ -42,6 +42,12 @@ Expression syntax for Get/Set:
   v.Set("Settings.TestArray[] = 2"); // Append a numeric type to an array
   v.Set("Settings.TestArray[] = { 'member': 100, 'something': 200 }"); // Append an object to an array
 ```
+* Strings that have quote characters break the normal Set method, so if the string is not KNOWN to be safe, use SetMemberString:
+```cpp
+  const char *pMyString = "'quoted'";
+  v.SetMemberString(pMyString, "Settings.TestArray[%d]", 1); // Recommended for any non-literal string, sets Settings.TestArrray[1] to 'quoted'
+```
+
 * To remove a key, use set without setting to anything (any children/subkeys are also removed)
 ```cpp
   v.Set("Settings"); // Remove the Settings key and all it's children
@@ -203,6 +209,7 @@ v.Get("key").AsFloat() == 3.14159
 Relevant methods:
 
   * udJSON::SetString(const char *pStr) - A copy of pStr is taken, if pStr is NULL this will fail and set to T_Void
+  * udJSON::SetMemberString(const char *pStr, const char *pExpression, ...) - A copy of pStr is taken, if pStr is NULL this will fail and set to T_Void
   * udJSON::AsBool() - Returns true if the string is "true" (ignores case) or is a numeric value >= 1.0
   * udJSON::AsInt() - Returns the result of udStrAtoi
   * udJSON::AsInt64() - Returns the result of udStrAtoi64

--- a/Include/udJSON.h
+++ b/Include/udJSON.h
@@ -185,8 +185,9 @@ public:
   // Set a new key/value pair to the store, overwriting a existing key, using = operator in the expression
   // Allowed operators are . and [] to dereference and for version without pValue, = to assign value (eg "obj.value = %d", 5)
   // Set with null for pValue or nothing following the = will remove the key
-  UD_PRINTF_FORMAT_FUNC(3) udResult Set(udJSON *pValue, const char *pKeyExpression, ...);
   UD_PRINTF_FORMAT_FUNC(2) udResult Set(const char *pKeyExpression, ...);
+  UD_PRINTF_FORMAT_FUNC(3) udResult Set(udJSON *pValue, const char *pKeyExpression, ...);
+  UD_PRINTF_FORMAT_FUNC(3) udResult SetMemberString(const char *pStringValue, const char *pKeyExpression, ...);
 
   // Parse a string an assign the type/value, supporting string, integer and float/double, JSON or XML
   udResult Parse(const char *pString, int *pCharCount = nullptr, int *pLineNumber = nullptr);

--- a/Source/udJSON.cpp
+++ b/Source/udJSON.cpp
@@ -939,6 +939,19 @@ udResult udJSON::Set(udJSON *pValue, const char *pKeyExpression, ...)
 
 // ****************************************************************************
 // Author: Dave Pevreal, April 2017
+udResult udJSON::SetMemberString(const char *pString, const char *pKeyExpression, ...)
+{
+  udJSON strValue;
+  strValue.SetString(pString);
+  va_list ap;
+  va_start(ap, pKeyExpression);
+  udResult result = udJSON_SetVA(this, &strValue, pKeyExpression, ap);
+  va_end(ap);
+  return result;
+}
+
+// ****************************************************************************
+// Author: Dave Pevreal, April 2017
 udResult udJSON::Parse(const char *pString, int *pCharCount, int *pLineNumber)
 {
   udResult result;
@@ -1007,6 +1020,12 @@ udResult udJSON::Parse(const char *pString, int *pCharCount, int *pLineNumber)
     type = T_String;
     u.pStr = pStr;
     totalCharCount += (int)endPos;
+    if (!pCharCount)
+    {
+      // Ensure nothing following the quotes
+      const char *pCheckEnd = udStrSkipWhiteSpace(pString + endPos);
+      UD_ERROR_IF(*pCheckEnd, udR_ParseError);
+    }
   }
   else
   {

--- a/udTest/src/udJSONTests.cpp
+++ b/udTest/src/udJSONTests.cpp
@@ -63,7 +63,10 @@ TEST(udJSONTests, CreationSimple)
   EXPECT_EQ(udR_Success, v.Set("Settings.Outside.content = 'windy'")); // This is a special member that will export as content text to the XML element
   g_udBreakOnError = false;
   EXPECT_NE(udR_Success, v.Set("Settings.Something"));
+  EXPECT_NE(udR_Success, v.Set("Settings.MyString = 'has ' quote'")); // Should fail because of errant quote character
   g_udBreakOnError = true;
+  EXPECT_EQ(udR_Success, v.Set("Settings.MyString = 'has \\' quote'")); // Quote character escaped
+  EXPECT_EQ(0, udStrcmp(v.Get("Settings.MyString").AsString(), "has ' quote"));
   EXPECT_EQ(udR_Success, v.Set("Settings.EmptyArray = []"));
   EXPECT_EQ(udR_Success, v.Set("Settings.Nothing = null"));
   // Of note here is that the input string is currently JSON escaped, so there's some additional backslashes
@@ -403,26 +406,13 @@ TEST(udJSONTests, SpecialCharacterCompliance)
   const char *pExportText = nullptr;
   const char validStr[] = R"str({"quotationMark":"\"","reverseSolidus":"\\","backspace":"\b","formFeed":"\f","lineFeed":"\n","carriageReturn":"\r","tabulation":"\t"})str";
 
-  temp.SetString("\"");
-  in.Set(&temp, "quotationMark");
-
-  temp.SetString("\\");
-  in.Set(&temp, "reverseSolidus");
-
-  temp.SetString("\b");
-  in.Set(&temp, "backspace");
-
-  temp.SetString("\f");
-  in.Set(&temp, "formFeed");
-
-  temp.SetString("\n");
-  in.Set(&temp, "lineFeed");
-
-  temp.SetString("\r");
-  in.Set(&temp, "carriageReturn");
-
-  temp.SetString("\t");
-  in.Set(&temp, "tabulation");
+  in.SetMemberString("\"", "quotationMark");
+  in.SetMemberString("\\", "reverseSolidus");
+  in.SetMemberString("\b", "backspace");
+  in.SetMemberString("\f", "formFeed");
+  in.SetMemberString("\n", "lineFeed");
+  in.SetMemberString("\r", "carriageReturn");
+  in.SetMemberString("\t", "tabulation");
 
   ASSERT_EQ(udR_Success, in.Export(&pExportText));
   EXPECT_TRUE(udStrEqual(validStr, pExportText));


### PR DESCRIPTION
This solves the issue of not being able to set strings that have quote characters with the normal Set() method.
Also reordered a couple of Set variants to match order in implementation